### PR TITLE
[Draft] Update to work with vvvv gamma 7

### DIFF
--- a/VL.Pipette.HDE.vl
+++ b/VL.Pipette.HDE.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="J5JcLMG6d92L52jSnbSp4u" LanguageVersion="2024.6.7-0145-g7866bdf1e8" Version="0.128">
-  <NugetDependency Id="M5KjIwXBlsjPW0u3Lyubp6" Location="VL.CoreLib" Version="2024.6.7-0145-g7866bdf1e8" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="J2uod0d93DROp5REpOxEYw" LanguageVersion="2025.7.0" Version="0.128">
+  <NugetDependency Id="M5KjIwXBlsjPW0u3Lyubp6" Location="VL.CoreLib" Version="2025.7.0" />
   <Patch Id="F7bnzPLW06JPZzJNwudf2b">
     <Canvas Id="Bir0z0GB6wqMBKzMwb1Y5m" DefaultCategory="HDE" CanvasType="FullCategory">
       <!--
@@ -14,7 +14,135 @@
         </p:NodeReference>
         <Patch Id="TzSeMNpxrmHPEViIvgwKE9">
           <Canvas Id="CHZVgJVQXoTQAAKAfFIPmS" CanvasType="Group">
-            <Node Bounds="327,899,105,19" Id="OjS6qmbhO0WPFIV6mLeKrr">
+            <Node Bounds="294,449,93,26" Id="QZL8cPFmyBGPQGUdiiwU4T">
+              <p:NodeReference LastCategoryFullName="System.Drawing.Graphics" LastDependency="System.Drawing.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="CopyFromScreen" />
+                <PinReference Kind="InputPin" Name="Upper Left Source" />
+              </p:NodeReference>
+              <Pin Id="JjSzdFTAnigLlyFlXC63j8" Name="Input" Kind="StateInputPin" />
+              <Pin Id="EWyaOrh0llzO8UFxnTmTna" Name="Upper Left Source" Kind="InputPin" />
+              <Pin Id="V6A0Z4JyLDlNskGvdd1xAV" Name="Upper Left Destination" Kind="InputPin" />
+              <Pin Id="KPk9m7qZvAOQMPmRH3AtVR" Name="Block Region Size" Kind="InputPin" />
+              <Pin Id="KHZTEeHqHRpMrrZUdXLza0" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <Node Bounds="395,297,46,26" Id="IuErMjIQSYVMMk4GnmKhtc">
+              <p:NodeReference LastCategoryFullName="System.Drawing.Size" LastDependency="System.Drawing.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="AssemblyCategory" Name="Size" />
+                <Choice Kind="OperationCallFlag" Name="Create" />
+                <PinReference Kind="InputPin" Name="Width" />
+              </p:NodeReference>
+              <Pin Id="CyRpIBMN7bbQTJdH4l9fUI" Name="Width" Kind="InputPin" DefaultValue="10" />
+              <Pin Id="UuztRNhHTYyM9DncAvUCkS" Name="Height" Kind="InputPin" DefaultValue="10" />
+              <Pin Id="DvQua5VYEucN8G6puOLQl2" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <Pad Id="Ecm9V0MI70EPDqiORuCmXn" Comment="Width" Bounds="437,244,35,15" ShowValueBox="true" isIOBox="true" Value="1">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="Integer32" />
+              </p:TypeAnnotation>
+            </Pad>
+            <Node Bounds="450,364,53,26" Id="F0AKpn76yyrLOCZsO0bPtn">
+              <p:NodeReference LastCategoryFullName="System.Drawing.Bitmap" LastDependency="System.Drawing.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="AssemblyCategory" Name="Bitmap" />
+                <Choice Kind="OperationCallFlag" Name="GetPixel" />
+              </p:NodeReference>
+              <Pin Id="RDkdCDEUULJLw3V5je2P3B" Name="Input" Kind="StateInputPin" />
+              <Pin Id="SFYWd2SB0gdPcaGTWAtjqc" Name="X" Kind="InputPin" />
+              <Pin Id="EtRhALCkZwfPQ919bPUJ6y" Name="Y" Kind="InputPin" />
+              <Pin Id="NmEMwCNzKNDMaFeiA6gsi4" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="OEow42pnFTHM0Fq6lz77Dz" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Pad Id="JSv5IbWmPHNMTY3linMqMQ" Comment="" Bounds="488,310,35,15" ShowValueBox="true" isIOBox="true" Value="0">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="Integer32" />
+              </p:TypeAnnotation>
+            </Pad>
+            <Node Bounds="123,390,53,19" Id="DCi1UQPzlcXNysW38y0QbI">
+              <p:NodeReference LastCategoryFullName="System.Windows.Forms.Cursor" LastDependency="System.Windows.Forms.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="AssemblyCategory" Name="Cursor" />
+                <Choice Kind="OperationCallFlag" Name="Position" />
+              </p:NodeReference>
+              <Pin Id="KFSdj2Gh4fLO89CT7WEU70" Name="Position" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="499,410,36,26" Id="EAyVjArBIujL4zZfehF8IQ">
+              <p:NodeReference LastCategoryFullName="System.Drawing.Color" LastDependency="System.Drawing.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="AssemblyCategory" Name="Color" />
+                <Choice Kind="OperationCallFlag" Name="R" />
+              </p:NodeReference>
+              <Pin Id="Au2N2j7xipMMZRVjFt3oLs" Name="Input" Kind="StateInputPin" />
+              <Pin Id="H5xWapjFoiCOYf0fztJxVY" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="IP2PvgGWEFZLfer4koVOry" Name="R" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="500,467,36,26" Id="TapoDPLBAsdNePnMkb8mJX">
+              <p:NodeReference LastCategoryFullName="System.Drawing.Color" LastDependency="System.Drawing.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="G" />
+                <CategoryReference Kind="AssemblyCategory" Name="Color" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="DdTNpc0AIwCPoXdDQvhuCz" Name="Input" Kind="StateInputPin" />
+              <Pin Id="GzRNib0gmX5MwONj6uv5Ur" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="GFgQhXHjiMdM5DwZ2ZBelu" Name="G" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="504,521,36,26" Id="AmpeK6wUt1hPk8c4Qp4aEC">
+              <p:NodeReference LastCategoryFullName="System.Drawing.Color" LastDependency="System.Drawing.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="B" />
+                <CategoryReference Kind="AssemblyCategory" Name="Color" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="M1qXmWgJ0vcMlIAL4jikvM" Name="Input" Kind="StateInputPin" />
+              <Pin Id="MG1jyEOpE2PLLr788JZLqG" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="Txu77V0W6RYM3Bw7MdpdVm" Name="B" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="523,607,65,19" Id="B2fCiLuBVxWOmJiImdM8rJ">
+              <p:NodeReference LastCategoryFullName="Color.RGBA" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="ColorRGBAType" Name="RGBA" />
+                <Choice Kind="OperationCallFlag" Name="RGBA (Join)" />
+              </p:NodeReference>
+              <Pin Id="LHrewnSUqYqQJSydWTTrrE" Name="Red" Kind="InputPin" />
+              <Pin Id="PWlYl49DWxULY7VczqzZzb" Name="Green" Kind="InputPin" />
+              <Pin Id="IfVJVIbw1nUMjlJTfSzF5K" Name="Blue" Kind="InputPin" />
+              <Pin Id="TTv9Spx1LP1OvJ8NwVNyi8" Name="Alpha" Kind="InputPin" />
+              <Pin Id="VVzNbsglL33O67sxEkPzHJ" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="552,446,25,19" Id="SEQafpyAbpwOXVAIKxJ7ca">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="/" />
+              </p:NodeReference>
+              <Pin Id="R9UzIf0G0ocPyeWde6Cw0x" Name="Input" Kind="InputPin" />
+              <Pin Id="Vz6lRwUfTQaLbUYWTSDglg" Name="Input 2" Kind="InputPin" />
+              <Pin Id="TRK06lVFCdtLjbWm4cMkfl" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Pad Id="Nbsy9irNNgGM8XscfAd8V5" Comment="" Bounds="577,412,39,15" ShowValueBox="true" isIOBox="true" Value="255">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="Float32" />
+              </p:TypeAnnotation>
+            </Pad>
+            <Node Bounds="556,501,25,19" Id="QHkSnhhq8MJLmmilHMQ09g">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="/" />
+              </p:NodeReference>
+              <Pin Id="Ok4fW6MnviFMkxPPmqGTSZ" Name="Input" Kind="InputPin" />
+              <Pin Id="CzHkhAUbmZAM67rr4WmnzZ" Name="Input 2" Kind="InputPin" />
+              <Pin Id="KqJ8s1hxGiQMJYutPytT36" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="551,561,25,19" Id="PluLjWxUy4DNnIFBOVFunm">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="/" />
+              </p:NodeReference>
+              <Pin Id="DQN6PaSkNO3LEzx4z8cvpP" Name="Input" Kind="InputPin" />
+              <Pin Id="GpLiLJxCDfWL2neMsaTEhw" Name="Input 2" Kind="InputPin" />
+              <Pin Id="UKDfppEFusyPszy2Ac3S0V" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Pad Id="PM0yvP0YNTWQB9927eyBEY" Comment="" Bounds="576,698,136,15" ShowValueBox="true" isIOBox="true" />
+            <Node Bounds="405,745,105,19" Id="OjS6qmbhO0WPFIV6mLeKrr">
               <p:NodeReference LastCategoryFullName="Graphics.Skia.Layers.Text" LastDependency="VL.Skia.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="Text" />
@@ -32,7 +160,7 @@
               <Pin Id="CHNM9tqBK1TOWaNDjTcPnn" Name="Output" Kind="OutputPin" />
               <Pin Id="ILoV6mmPN5ZOjQ9A1imASI" Name="Baseline Position" Kind="OutputPin" />
             </Node>
-            <Node Bounds="327,952,65,19" Id="UVA2sVrOGOwPuZoEf2xboA">
+            <Node Bounds="495,824,65,19" Id="UVA2sVrOGOwPuZoEf2xboA">
               <p:NodeReference LastCategoryFullName="Graphics.Skia" LastDependency="VL.Skia.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="Group" />
@@ -45,7 +173,15 @@
               <Pin Id="BmTTq29g2WQPtJSMHWv2T4" Name="Enabled" Kind="InputPin" />
               <Pin Id="B8JepBlveYNPj5EfneExji" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="725,98,75,19" Id="Ep7klrq5GjDLusCTc8Xvyx">
+            <Node Bounds="464,650,46,19" Id="K9i1FDA9puFNhJ6EzB27kr">
+              <p:NodeReference LastCategoryFullName="Color.RGBA" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="ToHex" />
+              </p:NodeReference>
+              <Pin Id="HBvhorXJ4hdMo1XxqyVhbr" Name="Color" Kind="InputPin" />
+              <Pin Id="VoCDYGjSDHnOTyYRFbasVj" Name="Hex" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="836,320,75,19" Id="Ep7klrq5GjDLusCTc8Xvyx">
               <p:NodeReference LastCategoryFullName="Gma.System.MouseKeyHook.Hook" LastDependency="Gma.System.MouseKeyHook.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="Hook" />
@@ -53,7 +189,7 @@
               </p:NodeReference>
               <Pin Id="L0zlMC6at32M4R3zNrdDUK" Name="Result" Kind="OutputPin" />
             </Node>
-            <Node Bounds="725,212,280,209" Id="T1VgX9NpU68O6Jpv96fUQn">
+            <Node Bounds="839,461,281,209" Id="T1VgX9NpU68O6Jpv96fUQn">
               <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="ProcessAppFlag" Name="ForEach (Keep)" />
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
@@ -61,6 +197,7 @@
               <Pin Id="Oa79vVSpuVHL4brFZm0yfV" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="VSE105JSGHYLExsEVNA5uw" Name="Messages" Kind="InputPin" />
               <Pin Id="FWVU4NMVm6tNVrRP4eR6Uf" Name="Reset" Kind="InputPin" />
+              <Pin Id="GUAgx6Liy1HNvI2y4XBEHi" Name="Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="KoUuwg3OkLKQSGXXeqHJIq" Name="Result" Kind="OutputPin" />
               <Patch Id="VlvHNWN2g4XNwN9Yi9uXU0" ManuallySortedPins="true">
                 <Patch Id="VHq7mfzttwRLTpfDCMhkuo" Name="Create" ManuallySortedPins="true" />
@@ -69,10 +206,10 @@
                   <Pin Id="PRygMNIzriaL2WI7EWdB7O" Name="Output 1" Kind="OutputPin" />
                   <Pin Id="V1AlCKrWhdELgh2f1MY5PV" Name="Output 2" Kind="OutputPin" />
                 </Patch>
-                <ControlPoint Id="U2Il2CDb2FpQKDmlrIj56t" Bounds="738,220" />
-                <ControlPoint Id="Ayhonw7NV1aOZCzWaNBjke" Bounds="743,414" />
-                <ControlPoint Id="DDqVQcahmAbNzchnxqIQBz" Bounds="807,388" />
-                <Node Bounds="737,238,62,26" Id="FB3WrsLHdQ3ObrpqCp7LIF">
+                <ControlPoint Id="U2Il2CDb2FpQKDmlrIj56t" Bounds="852,469" />
+                <ControlPoint Id="Ayhonw7NV1aOZCzWaNBjke" Bounds="857,663" />
+                <ControlPoint Id="DDqVQcahmAbNzchnxqIQBz" Bounds="921,637" />
+                <Node Bounds="851,487,62,26" Id="FB3WrsLHdQ3ObrpqCp7LIF">
                   <p:NodeReference LastCategoryFullName="Reactive.EventPattern" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="RecordType" Name="EventPattern" />
@@ -81,7 +218,7 @@
                   <Pin Id="KSMlUwHziisNvvY2xYQ956" Name="Input" Kind="StateInputPin" />
                   <Pin Id="LYOspVrJDh6LQ4YyP2Xpn3" Name="Event Args" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="806,342,25,19" Id="Cfachhv7sqtNd4PYEvvw3L">
+                <Node Bounds="920,591,25,19" Id="Cfachhv7sqtNd4PYEvvw3L">
                   <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
@@ -91,7 +228,7 @@
                   <Pin Id="Cq7EI32JUf8MEL2gktno3I" Name="Input 2" Kind="InputPin" />
                   <Pin Id="A4O80rKkoW7MA9ysynuKMb" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="737,300,65,26" Id="B3jTyMT5ynnN1DLwEGCIUj">
+                <Node Bounds="851,549,65,26" Id="B3jTyMT5ynnN1DLwEGCIUj">
                   <p:NodeReference LastCategoryFullName="System.Windows.Forms.KeyEventArgs" LastDependency="System.Windows.Forms.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="KeyCode" />
@@ -101,15 +238,15 @@
                   <Pin Id="Hzzz4ZDd8sMMjg8IRE34vt" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="BGcZoZ8cJ5SPF7eoiD0ici" Name="Key Code" Kind="OutputPin" />
                 </Node>
-                <Pad Id="Iz8UQt2AyPkO4Q8YD2GtsJ" Comment="" Bounds="855,301,119,15" ShowValueBox="true" isIOBox="true" Value="Escape">
+                <Pad Id="Iz8UQt2AyPkO4Q8YD2GtsJ" Comment="" Bounds="969,550,120,15" ShowValueBox="true" isIOBox="true" Value="Escape">
                   <p:TypeAnnotation LastCategoryFullName="IO.Keyboard" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Keys" />
                   </p:TypeAnnotation>
                 </Pad>
               </Patch>
             </Node>
-            <Pad Id="OVNonTeEUUELgdXirbHavb" Bounds="727,139" />
-            <Node Bounds="726,460,65,19" Id="KOqkznrxgsZOl0qmToGVdD">
+            <Pad Id="OVNonTeEUUELgdXirbHavb" Bounds="843,371" />
+            <Node Bounds="843,740,65,19" Id="KOqkznrxgsZOl0qmToGVdD">
               <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
@@ -118,10 +255,20 @@
               <Pin Id="DuLK1zGBRYAO3AZ8bAiwWv" Name="Initial Result" Kind="InputPin" IsHidden="true" />
               <Pin Id="QcoNTf90utTM2XX2dus7Rk" Name="Async Notifications" Kind="InputPin" />
               <Pin Id="O0ZvJ2NZ3FxPMe4WSBd6hi" Name="Reset" Kind="InputPin" />
+              <Pin Id="LUVwAwC07gcNNZRtJTqxZM" Name="Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="G1k93Nxdc1zOHDZPI4GeAa" Name="Value" Kind="OutputPin" />
               <Pin Id="MslgFpjUj16LXaCsLYXhHS" Name="On Data" Kind="OutputPin" />
             </Node>
-            <Node Bounds="725,165,75,26" Id="VYhWXpMhGPzOMTMjBphle3">
+            <Node Bounds="815,844,51,19" Id="T0lvOhIPgQDO9CpcOh4h8j">
+              <p:NodeReference LastCategoryFullName="System.Windows.Forms.Clipboard" LastDependency="System.Windows.Forms.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="AssemblyCategory" Name="Clipboard" />
+                <Choice Kind="OperationCallFlag" Name="SetText" />
+              </p:NodeReference>
+              <Pin Id="OT5JeJ2Ljw1MU1rEtQ6aO9" Name="Text" Kind="InputPin" />
+              <Pin Id="LFfXsKFENbVPIRCRe6kvYZ" Name="Apply" Kind="InputPin" />
+            </Node>
+            <Node Bounds="848,394,75,26" Id="VYhWXpMhGPzOMTMjBphle3">
               <p:NodeReference LastCategoryFullName="Gma.System.MouseKeyHook.IKeyboardEvents" LastDependency="Gma.System.MouseKeyHook.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="IKeyboardEvents" NeedsToBeDirectParent="true" />
@@ -131,7 +278,7 @@
               <Pin Id="Sk57yy2W91GMj2QfpGlzuV" Name="State Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="EbDN0YyyCVTLA1pF5Y0kzl" Name="Result" Kind="OutputPin" />
             </Node>
-            <Node Bounds="347,924,105,19" Id="FpxzUmACeVROOr3Fqo6gVM">
+            <Node Bounds="551,773,105,19" Id="FpxzUmACeVROOr3Fqo6gVM">
               <p:NodeReference LastCategoryFullName="Graphics.Skia.Layers.Text" LastDependency="VL.Skia.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="Text" />
@@ -149,226 +296,65 @@
               <Pin Id="Rw3WAAolAICQF69Uj0nQf3" Name="Output" Kind="OutputPin" />
               <Pin Id="TWxuwWVKke7NPrkoihB8i9" Name="Baseline Position" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="KsOqaihEpF8PoQKSspIZFO" Bounds="221,80" />
-            <ControlPoint Id="Gq9ho2e4fDxMvpGGU45du5" Bounds="329,1005" />
-            <ControlPoint Id="E0ZlpdJwKtMPfL1JZZVjwp" Bounds="521,881" />
-            <Node Bounds="143,155,478,704" Id="STVnRnP1fTRNmDnqaoWrwP">
+            <Node Bounds="197,182,188,231" Id="DZtmOoHz6ITMq18k9FV1J5">
               <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                <CategoryReference Kind="Category" Name="Primitive" />
-                <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                <FullNameCategoryReference ID="Primitive" />
               </p:NodeReference>
-              <Pin Id="MCYayua0SVlLpzKqMOtCoc" Name="Condition" Kind="InputPin" />
-              <Patch Id="Lp0XDlCexoHN0s5ttuWHsb" ManuallySortedPins="true">
-                <Patch Id="HKxUnL4LIKtNPbJ4gMhOnL" Name="Create" ManuallySortedPins="true" />
-                <Patch Id="BBHXmZM3SloMNKanoC0vFR" Name="Then" ManuallySortedPins="true" />
-                <Node Bounds="238,458,93,26" Id="QZL8cPFmyBGPQGUdiiwU4T">
-                  <p:NodeReference LastCategoryFullName="System.Drawing.Graphics" LastDependency="System.Drawing.dll">
+              <Pin Id="B8AwLZ5EYcNNeh16msL4MO" Name="Force" Kind="InputPin" />
+              <Pin Id="QfTm4IJ758dL5hPc9wb8Fn" Name="Dispose Cached Outputs" Kind="InputPin" DefaultValue="True" />
+              <Pin Id="EJLaqShJ9ypQDn24DDjLkm" Name="Has Changed" Kind="OutputPin" />
+              <Patch Id="SMIJlyvVy0hOS0lTjsVumP" ManuallySortedPins="true">
+                <Patch Id="QhxDPBHS43VPocWl0EPmHj" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="RT3Te615tRxNs1LNMYGEXG" Name="Then" ManuallySortedPins="true" />
+                <Node Bounds="209,205,85,26" Id="PqntEBESu79OArfatrm4Fv">
+                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.Control" LastDependency="System.Windows.Forms.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="CopyFromScreen" />
-                    <PinReference Kind="InputPin" Name="Upper Left Source" />
+                    <Choice Kind="OperationCallFlag" Name="CreateGraphics" />
                   </p:NodeReference>
-                  <Pin Id="JjSzdFTAnigLlyFlXC63j8" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="EWyaOrh0llzO8UFxnTmTna" Name="Upper Left Source" Kind="InputPin" />
-                  <Pin Id="V6A0Z4JyLDlNskGvdd1xAV" Name="Upper Left Destination" Kind="InputPin" />
-                  <Pin Id="KPk9m7qZvAOQMPmRH3AtVR" Name="Block Region Size" Kind="InputPin" />
-                  <Pin Id="KHZTEeHqHRpMrrZUdXLza0" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="RBnRkKTgpqJP4JIrTTY73k" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="JZ7M6IcmT9mOwYIDaLlz2d" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="U4H2YUN9QCeNPboiBSEVfi" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="268,417,53,19" Id="DCi1UQPzlcXNysW38y0QbI">
-                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.Cursor" LastDependency="System.Windows.Forms.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="Cursor" />
-                    <Choice Kind="OperationCallFlag" Name="Position" />
-                  </p:NodeReference>
-                  <Pin Id="KFSdj2Gh4fLO89CT7WEU70" Name="Position" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="187,190,188,186" Id="DZtmOoHz6ITMq18k9FV1J5">
-                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                    <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                    <Choice Kind="ProcessStatefulRegion" Name="Cache" />
-                    <FullNameCategoryReference ID="Primitive" />
-                  </p:NodeReference>
-                  <Pin Id="B8AwLZ5EYcNNeh16msL4MO" Name="Force" Kind="InputPin" />
-                  <Pin Id="QfTm4IJ758dL5hPc9wb8Fn" Name="Dispose Cached Outputs" Kind="InputPin" DefaultValue="True" />
-                  <Pin Id="EJLaqShJ9ypQDn24DDjLkm" Name="Has Changed" Kind="OutputPin" />
-                  <Patch Id="SMIJlyvVy0hOS0lTjsVumP" ManuallySortedPins="true">
-                    <Patch Id="QhxDPBHS43VPocWl0EPmHj" Name="Create" ManuallySortedPins="true" />
-                    <Patch Id="RT3Te615tRxNs1LNMYGEXG" Name="Then" ManuallySortedPins="true" />
-                    <Node Bounds="199,215,85,26" Id="PqntEBESu79OArfatrm4Fv">
-                      <p:NodeReference LastCategoryFullName="System.Windows.Forms.Control" LastDependency="System.Windows.Forms.dll">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="CreateGraphics" />
-                      </p:NodeReference>
-                      <Pin Id="RBnRkKTgpqJP4JIrTTY73k" Name="Input" Kind="StateInputPin" />
-                      <Pin Id="JZ7M6IcmT9mOwYIDaLlz2d" Name="Output" Kind="StateOutputPin" />
-                      <Pin Id="U4H2YUN9QCeNPboiBSEVfi" Name="Result" Kind="OutputPin" />
-                    </Node>
-                    <Node Bounds="238,263,46,26" Id="DGdpequte4FMXf1zAvRLRw">
-                      <p:NodeReference LastCategoryFullName="System.Drawing.Bitmap" LastDependency="System.Drawing.dll">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <CategoryReference Kind="AssemblyCategory" Name="Bitmap" />
-                        <Choice Kind="OperationCallFlag" Name="Create" />
-                        <PinReference Kind="InputPin" Name="Width" />
-                        <PinReference Kind="InputPin" Name="G" />
-                      </p:NodeReference>
-                      <Pin Id="LllZr6dPneXOXpEEmwcvgn" Name="Width" Kind="InputPin" />
-                      <Pin Id="G7VbaoqZ0KyMCdn4JIBZYX" Name="Height" Kind="InputPin" />
-                      <Pin Id="PuF4xC6hed3LlihRCRsD0Y" Name="G" Kind="InputPin" />
-                      <Pin Id="SWNPIaIiQmfOtqyLRIO5S0" Name="Output" Kind="StateOutputPin" />
-                    </Node>
-                    <Node Bounds="238,330,67,19" Id="EgIrKaAMajLNPtLMP1gh4t">
-                      <p:NodeReference LastCategoryFullName="System.Drawing.Graphics" LastDependency="System.Drawing.dll">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="FromImage" />
-                        <CategoryReference Kind="AssemblyCategory" Name="Graphics" NeedsToBeDirectParent="true" />
-                      </p:NodeReference>
-                      <Pin Id="LpYp40AgEA3OY7FcrKZ4cO" Name="Image" Kind="InputPin" />
-                      <Pin Id="LlnVnudKvbDMQgBS93no2i" Name="Result" Kind="OutputPin" />
-                    </Node>
-                  </Patch>
-                  <ControlPoint Id="OtoBp0tHAizQbL5kqjQHW7" Bounds="240,370" Alignment="Bottom" />
-                  <ControlPoint Id="JnBgBKLJfitNkjXzurByy5" Bounds="360,370" Alignment="Bottom" />
-                  <ControlPoint Id="IwKvCSsTS6OLH6BkQvJDNb" Bounds="201,196" Alignment="Top" />
-                </Node>
-                <Node Bounds="359,498,53,26" Id="F0AKpn76yyrLOCZsO0bPtn">
+                <Node Bounds="294,300,46,26" Id="DGdpequte4FMXf1zAvRLRw">
                   <p:NodeReference LastCategoryFullName="System.Drawing.Bitmap" LastDependency="System.Drawing.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="Bitmap" />
-                    <Choice Kind="OperationCallFlag" Name="GetPixel" />
-                  </p:NodeReference>
-                  <Pin Id="RDkdCDEUULJLw3V5je2P3B" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="SFYWd2SB0gdPcaGTWAtjqc" Name="X" Kind="InputPin" />
-                  <Pin Id="EtRhALCkZwfPQ919bPUJ6y" Name="Y" Kind="InputPin" />
-                  <Pin Id="NmEMwCNzKNDMaFeiA6gsi4" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="OEow42pnFTHM0Fq6lz77Dz" Name="Result" Kind="OutputPin" />
-                </Node>
-                <Pad Id="JSv5IbWmPHNMTY3linMqMQ" Comment="" Bounds="399,473,35,15" ShowValueBox="true" isIOBox="true" Value="0">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="TypeFlag" Name="Integer32" />
-                  </p:TypeAnnotation>
-                </Pad>
-                <Node Bounds="378,545,36,26" Id="EAyVjArBIujL4zZfehF8IQ">
-                  <p:NodeReference LastCategoryFullName="System.Drawing.Color" LastDependency="System.Drawing.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="Color" />
-                    <Choice Kind="OperationCallFlag" Name="R" />
-                  </p:NodeReference>
-                  <Pin Id="Au2N2j7xipMMZRVjFt3oLs" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="H5xWapjFoiCOYf0fztJxVY" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="IP2PvgGWEFZLfer4koVOry" Name="R" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="378,602,36,26" Id="TapoDPLBAsdNePnMkb8mJX">
-                  <p:NodeReference LastCategoryFullName="System.Drawing.Color" LastDependency="System.Drawing.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="G" />
-                    <CategoryReference Kind="AssemblyCategory" Name="Color" NeedsToBeDirectParent="true" />
-                  </p:NodeReference>
-                  <Pin Id="DdTNpc0AIwCPoXdDQvhuCz" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="GzRNib0gmX5MwONj6uv5Ur" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="GFgQhXHjiMdM5DwZ2ZBelu" Name="G" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="378,656,36,26" Id="AmpeK6wUt1hPk8c4Qp4aEC">
-                  <p:NodeReference LastCategoryFullName="System.Drawing.Color" LastDependency="System.Drawing.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="B" />
-                    <CategoryReference Kind="AssemblyCategory" Name="Color" NeedsToBeDirectParent="true" />
-                  </p:NodeReference>
-                  <Pin Id="M1qXmWgJ0vcMlIAL4jikvM" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="MG1jyEOpE2PLLr788JZLqG" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="Txu77V0W6RYM3Bw7MdpdVm" Name="B" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="402,742,65,19" Id="B2fCiLuBVxWOmJiImdM8rJ">
-                  <p:NodeReference LastCategoryFullName="Color.RGBA" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="ColorRGBAType" Name="RGBA" />
-                    <Choice Kind="OperationCallFlag" Name="RGBA (Join)" />
-                  </p:NodeReference>
-                  <Pin Id="LHrewnSUqYqQJSydWTTrrE" Name="Red" Kind="InputPin" />
-                  <Pin Id="PWlYl49DWxULY7VczqzZzb" Name="Green" Kind="InputPin" />
-                  <Pin Id="IfVJVIbw1nUMjlJTfSzF5K" Name="Blue" Kind="InputPin" />
-                  <Pin Id="TTv9Spx1LP1OvJ8NwVNyi8" Name="Alpha" Kind="InputPin" />
-                  <Pin Id="VVzNbsglL33O67sxEkPzHJ" Name="Result" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="431,581,25,19" Id="SEQafpyAbpwOXVAIKxJ7ca">
-                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="/" />
-                  </p:NodeReference>
-                  <Pin Id="R9UzIf0G0ocPyeWde6Cw0x" Name="Input" Kind="InputPin" />
-                  <Pin Id="Vz6lRwUfTQaLbUYWTSDglg" Name="Input 2" Kind="InputPin" />
-                  <Pin Id="TRK06lVFCdtLjbWm4cMkfl" Name="Output" Kind="OutputPin" />
-                </Node>
-                <Pad Id="Nbsy9irNNgGM8XscfAd8V5" Comment="" Bounds="456,547,48,15" ShowValueBox="true" isIOBox="true" Value="255">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="TypeFlag" Name="Float32" />
-                  </p:TypeAnnotation>
-                </Pad>
-                <Node Bounds="435,636,25,19" Id="QHkSnhhq8MJLmmilHMQ09g">
-                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="/" />
-                  </p:NodeReference>
-                  <Pin Id="Ok4fW6MnviFMkxPPmqGTSZ" Name="Input" Kind="InputPin" />
-                  <Pin Id="CzHkhAUbmZAM67rr4WmnzZ" Name="Input 2" Kind="InputPin" />
-                  <Pin Id="KqJ8s1hxGiQMJYutPytT36" Name="Output" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="430,696,25,19" Id="PluLjWxUy4DNnIFBOVFunm">
-                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="/" />
-                  </p:NodeReference>
-                  <Pin Id="DQN6PaSkNO3LEzx4z8cvpP" Name="Input" Kind="InputPin" />
-                  <Pin Id="GpLiLJxCDfWL2neMsaTEhw" Name="Input 2" Kind="InputPin" />
-                  <Pin Id="UKDfppEFusyPszy2Ac3S0V" Name="Output" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="404,781,46,19" Id="K9i1FDA9puFNhJ6EzB27kr">
-                  <p:NodeReference LastCategoryFullName="Color.RGBA" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="ToHex" />
-                  </p:NodeReference>
-                  <Pin Id="HBvhorXJ4hdMo1XxqyVhbr" Name="Color" Kind="InputPin" />
-                  <Pin Id="VoCDYGjSDHnOTyYRFbasVj" Name="Hex" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="409,820,51,19" Id="T0lvOhIPgQDO9CpcOh4h8j">
-                  <p:NodeReference LastCategoryFullName="System.Windows.Forms.Clipboard" LastDependency="System.Windows.Forms.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="Clipboard" />
-                    <Choice Kind="OperationCallFlag" Name="SetText" />
-                  </p:NodeReference>
-                  <Pin Id="OT5JeJ2Ljw1MU1rEtQ6aO9" Name="Text" Kind="InputPin" />
-                  <Pin Id="LFfXsKFENbVPIRCRe6kvYZ" Name="Apply" Kind="InputPin" />
-                </Node>
-                <Node Bounds="387,414,46,26" Id="IuErMjIQSYVMMk4GnmKhtc">
-                  <p:NodeReference LastCategoryFullName="System.Drawing.Size" LastDependency="System.Drawing.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="Size" />
                     <Choice Kind="OperationCallFlag" Name="Create" />
                     <PinReference Kind="InputPin" Name="Width" />
+                    <PinReference Kind="InputPin" Name="G" />
                   </p:NodeReference>
-                  <Pin Id="CyRpIBMN7bbQTJdH4l9fUI" Name="Width" Kind="InputPin" DefaultValue="10" />
-                  <Pin Id="UuztRNhHTYyM9DncAvUCkS" Name="Height" Kind="InputPin" DefaultValue="10" />
-                  <Pin Id="DvQua5VYEucN8G6puOLQl2" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="LllZr6dPneXOXpEEmwcvgn" Name="Width" Kind="InputPin" />
+                  <Pin Id="G7VbaoqZ0KyMCdn4JIBZYX" Name="Height" Kind="InputPin" />
+                  <Pin Id="PuF4xC6hed3LlihRCRsD0Y" Name="G" Kind="InputPin" />
+                  <Pin Id="SWNPIaIiQmfOtqyLRIO5S0" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Pad Id="Ecm9V0MI70EPDqiORuCmXn" Comment="Width" Bounds="420,239,35,15" ShowValueBox="true" isIOBox="true" Value="1">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="TypeFlag" Name="Integer32" />
-                  </p:TypeAnnotation>
-                </Pad>
+                <Node Bounds="294,367,67,19" Id="EgIrKaAMajLNPtLMP1gh4t">
+                  <p:NodeReference LastCategoryFullName="System.Drawing.Graphics" LastDependency="System.Drawing.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="FromImage" />
+                    <CategoryReference Kind="AssemblyCategory" Name="Graphics" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="LpYp40AgEA3OY7FcrKZ4cO" Name="Image" Kind="InputPin" />
+                  <Pin Id="LlnVnudKvbDMQgBS93no2i" Name="Result" Kind="OutputPin" />
+                </Node>
               </Patch>
-              <ControlPoint Id="GRcz8ewfi1ePGGymEItmvD" Bounds="521,853" Alignment="Bottom" />
-              <ControlPoint Id="NXXcPv0XrdoL326xzz8rIc" Bounds="604,161" Alignment="Top" />
-              <ControlPoint Id="SucSbJns5j6MtTTdL9AFI3" Bounds="389,853" Alignment="Bottom" />
-              <ControlPoint Id="HepEiKuRaFKM7PjVIzyVgh" Bounds="461,161" Alignment="Top" />
+              <ControlPoint Id="OtoBp0tHAizQbL5kqjQHW7" Bounds="296,407" Alignment="Bottom" />
+              <ControlPoint Id="JnBgBKLJfitNkjXzurByy5" Bounds="370,407" Alignment="Bottom" />
             </Node>
-            <Node Bounds="140,102,65,19" Id="JGhq8yBO0hYLgDkh14uRPt">
-              <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+            <Node Bounds="105,146,54,19" Id="QP7QW13nSxNOLuqjhTKct2">
+              <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="IsAssigned" />
+                <Choice Kind="ProcessAppFlag" Name="OnOpen" />
               </p:NodeReference>
-              <Pin Id="PzFBohWfGioOwzBgDx9FYz" Name="X" Kind="InputPin" />
-              <Pin Id="Kg0m7Yy4qGSOMhfKXakiNI" Name="Result" Kind="OutputPin" />
-              <Pin Id="D5vQf2ny5rhMEiem5kK92k" Name="Not Assigned" Kind="OutputPin" />
+              <Pin Id="BzF34Zg4QafP4m2x0jibzH" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="UaNBMAdvdMUPa8kKR1zBjT" Name="Simulate" Kind="InputPin" />
+              <Pin Id="Sh9CiOrQjgJMJ8q6m2Sswx" Name="Output" Kind="OutputPin" />
             </Node>
+            <ControlPoint Id="KsOqaihEpF8PoQKSspIZFO" Bounds="213,160" />
+            <ControlPoint Id="Gq9ho2e4fDxMvpGGU45du5" Bounds="397,887" />
+            <ControlPoint Id="E0ZlpdJwKtMPfL1JZZVjwp" Bounds="587,657" />
           </Canvas>
           <Patch Id="PgAFvVNkToDL4r6QHeUy5l" Name="Create" ParticipatingElements="Ep7klrq5GjDLusCTc8Xvyx" />
           <Patch Id="B0FqNDx6JtYNVtglYxxhd2" Name="Update">
@@ -385,38 +371,9 @@
           <Link Id="OVP2sbWeMELNRhVHw4xXQ5" Ids="Ecm9V0MI70EPDqiORuCmXn,UuztRNhHTYyM9DncAvUCkS" />
           <Link Id="Eg9V9jUggAhLdazydq1VBv" Ids="Ecm9V0MI70EPDqiORuCmXn,LllZr6dPneXOXpEEmwcvgn" />
           <Link Id="LwPth5fwOAFLnfIOQiEAD4" Ids="Ecm9V0MI70EPDqiORuCmXn,G7VbaoqZ0KyMCdn4JIBZYX" />
-          <Link Id="B7KUxTQNDTrMOUaha5Gxlr" Ids="KFSdj2Gh4fLO89CT7WEU70,EWyaOrh0llzO8UFxnTmTna" />
-          <Link Id="CNrBoQdOs8zM2pe90p6cbw" Ids="CHNM9tqBK1TOWaNDjTcPnn,EnQFmt0jbV3MwE7xfMiE9k" />
-          <Link Id="JJMgifCdIqiN2qC3bKGguj" Ids="FrUpxDjxhbzMHPnwBbRf6I,U2Il2CDb2FpQKDmlrIj56t" IsHidden="true" />
-          <Link Id="AEA6LbetEzINoCpcEvxIqP" Ids="Ayhonw7NV1aOZCzWaNBjke,PRygMNIzriaL2WI7EWdB7O" IsHidden="true" />
-          <Link Id="C3CvASHIDwxLZzK7PuV8pY" Ids="DDqVQcahmAbNzchnxqIQBz,V1AlCKrWhdELgh2f1MY5PV" IsHidden="true" />
-          <Link Id="HTvrjMJ36X8MpTX7QuSE0j" Ids="U2Il2CDb2FpQKDmlrIj56t,KSMlUwHziisNvvY2xYQ956" />
-          <Link Id="KB0YFyVQRuWMDuDvu3OpkL" Ids="L0zlMC6at32M4R3zNrdDUK,OVNonTeEUUELgdXirbHavb" />
-          <Link Id="VOyhkEbtNgMNgU1Q34tOnw" Ids="A4O80rKkoW7MA9ysynuKMb,DDqVQcahmAbNzchnxqIQBz" />
-          <Link Id="NGLuth4RO1hPLpeVFvYeKc" Ids="KoUuwg3OkLKQSGXXeqHJIq,QcoNTf90utTM2XX2dus7Rk" />
-          <Link Id="FjgnQgievQBM7nIOLdTISS" Ids="MslgFpjUj16LXaCsLYXhHS,LFfXsKFENbVPIRCRe6kvYZ" />
-          <Link Id="NyQNElx6XgMN9vQKeTc7T7" Ids="OVNonTeEUUELgdXirbHavb,NDqg11vVcIGN6LKo1YrF0M" />
-          <Link Id="GqiNkWSaNlSMano5o2SyQa" Ids="EbDN0YyyCVTLA1pF5Y0kzl,VSE105JSGHYLExsEVNA5uw" />
-          <Link Id="RQC4POlxPyrNvUjnnaKt2o" Ids="LYOspVrJDh6LQ4YyP2Xpn3,LIcIvJ6vtwoNlcZXJTtmte" />
-          <Link Id="QnKomcQYfbJN0xaEZYg2sY" Ids="BGcZoZ8cJ5SPF7eoiD0ici,QZbwOcgIZ2UNE8LED9EDOl" />
-          <Link Id="Ses4mQLC7NSN00jkBNmoyT" Ids="Iz8UQt2AyPkO4Q8YD2GtsJ,Cq7EI32JUf8MEL2gktno3I" />
-          <Link Id="GMKhF5WaAElMZ4KLLeyT8j" Ids="Hzzz4ZDd8sMMjg8IRE34vt,Ayhonw7NV1aOZCzWaNBjke" />
-          <Link Id="OauPBJbbuEZOmCLRpliwxy" Ids="Rw3WAAolAICQF69Uj0nQf3,Sr7tB3d11SSMPoKjaUOips" />
-          <Link Id="JtadHXAfLPOO9UeWtBjpLO" Ids="OtoBp0tHAizQbL5kqjQHW7,JjSzdFTAnigLlyFlXC63j8" />
-          <Link Id="EWpgrCigZ69MdUs3YnrB0J" Ids="SELaYz987gJPWnPmwbZclL,KsOqaihEpF8PoQKSspIZFO" IsHidden="true" />
-          <Link Id="A53GRicfZlsPaI8uoRTyzn" Ids="B8JepBlveYNPj5EfneExji,Gq9ho2e4fDxMvpGGU45du5" />
-          <Link Id="SBVmYABYDtDL7tzIMGLzpy" Ids="Gq9ho2e4fDxMvpGGU45du5,OdDouNds1VRPZnpOzlcANk" IsHidden="true" />
-          <Link Id="UIl8keKAKA9QZdRbT55Ps3" Ids="E0ZlpdJwKtMPfL1JZZVjwp,Eypxf2jGavDNZkg5yTfufO" IsHidden="true" />
-          <Link Id="HKfDKAgt94wP6IwUwCfSAM" Ids="KsOqaihEpF8PoQKSspIZFO,IwKvCSsTS6OLH6BkQvJDNb" />
-          <Link Id="I2znmJnLR12NfXYAGil1gj" Ids="Kg0m7Yy4qGSOMhfKXakiNI,MCYayua0SVlLpzKqMOtCoc" />
-          <Link Id="JpXyoK941jqQSGFbNrLDwb" Ids="KsOqaihEpF8PoQKSspIZFO,PzFBohWfGioOwzBgDx9FYz" />
-          <Link Id="MrWxebtYZVWQGAyZlm5fSB" Ids="U4H2YUN9QCeNPboiBSEVfi,PuF4xC6hed3LlihRCRsD0Y" />
-          <Link Id="SCzz5qmF3sHQFnOSs7k2P4" Ids="SWNPIaIiQmfOtqyLRIO5S0,LpYp40AgEA3OY7FcrKZ4cO" />
-          <Link Id="SCCc9dObNm6Ovpj3UlusIC" Ids="LlnVnudKvbDMQgBS93no2i,OtoBp0tHAizQbL5kqjQHW7" />
-          <Link Id="H8mBAQYRPKjQIYGSRhJWt1" Ids="SWNPIaIiQmfOtqyLRIO5S0,JnBgBKLJfitNkjXzurByy5" />
-          <Link Id="Sxbe6uN4g1bPxyNirlYq8V" Ids="IwKvCSsTS6OLH6BkQvJDNb,RBnRkKTgpqJP4JIrTTY73k" />
           <Link Id="HZJioGD38CeNICxhy0b79j" Ids="JSv5IbWmPHNMTY3linMqMQ,SFYWd2SB0gdPcaGTWAtjqc" />
           <Link Id="CHcpVgjwI4mMxG1lYSlloj" Ids="JSv5IbWmPHNMTY3linMqMQ,EtRhALCkZwfPQ919bPUJ6y" />
+          <Link Id="B7KUxTQNDTrMOUaha5Gxlr" Ids="KFSdj2Gh4fLO89CT7WEU70,EWyaOrh0llzO8UFxnTmTna" />
           <Link Id="NcXSePVRMHBQRzc4MwTMZn" Ids="OEow42pnFTHM0Fq6lz77Dz,Au2N2j7xipMMZRVjFt3oLs" />
           <Link Id="SObhGUila3cMvJQllg45fZ" Ids="H5xWapjFoiCOYf0fztJxVY,DdTNpc0AIwCPoXdDQvhuCz" />
           <Link Id="IJlQsnEIojVMhabvdIb5gJ" Ids="GzRNib0gmX5MwONj6uv5Ur,M1qXmWgJ0vcMlIAL4jikvM" />
@@ -429,15 +386,39 @@
           <Link Id="BHvblTsErCePgnBuvbATLc" Ids="TRK06lVFCdtLjbWm4cMkfl,LHrewnSUqYqQJSydWTTrrE" />
           <Link Id="Bzg0ZDPnSN8QYeFYxBAaWa" Ids="KqJ8s1hxGiQMJYutPytT36,PWlYl49DWxULY7VczqzZzb" />
           <Link Id="VerBw1Q0Z0QQYtLnPyWulI" Ids="UKDfppEFusyPszy2Ac3S0V,IfVJVIbw1nUMjlJTfSzF5K" />
+          <Link Id="MuMywWheAMEPaEdFO3Swfg" Ids="VVzNbsglL33O67sxEkPzHJ,PM0yvP0YNTWQB9927eyBEY" />
+          <Link Id="CNrBoQdOs8zM2pe90p6cbw" Ids="CHNM9tqBK1TOWaNDjTcPnn,EnQFmt0jbV3MwE7xfMiE9k" />
           <Link Id="B9VXFgXVdytM9uVfuUxU7m" Ids="VVzNbsglL33O67sxEkPzHJ,HBvhorXJ4hdMo1XxqyVhbr" />
+          <Link Id="PpFFjiIJBxzPGeiUuDdFEl" Ids="VoCDYGjSDHnOTyYRFbasVj,RMOpHoE51oKM82IPZhdn0z" />
+          <Link Id="JJMgifCdIqiN2qC3bKGguj" Ids="FrUpxDjxhbzMHPnwBbRf6I,U2Il2CDb2FpQKDmlrIj56t" IsHidden="true" />
+          <Link Id="AEA6LbetEzINoCpcEvxIqP" Ids="Ayhonw7NV1aOZCzWaNBjke,PRygMNIzriaL2WI7EWdB7O" IsHidden="true" />
+          <Link Id="C3CvASHIDwxLZzK7PuV8pY" Ids="DDqVQcahmAbNzchnxqIQBz,V1AlCKrWhdELgh2f1MY5PV" IsHidden="true" />
+          <Link Id="HTvrjMJ36X8MpTX7QuSE0j" Ids="U2Il2CDb2FpQKDmlrIj56t,KSMlUwHziisNvvY2xYQ956" />
+          <Link Id="KB0YFyVQRuWMDuDvu3OpkL" Ids="L0zlMC6at32M4R3zNrdDUK,OVNonTeEUUELgdXirbHavb" />
+          <Link Id="VOyhkEbtNgMNgU1Q34tOnw" Ids="A4O80rKkoW7MA9ysynuKMb,DDqVQcahmAbNzchnxqIQBz" />
+          <Link Id="NGLuth4RO1hPLpeVFvYeKc" Ids="KoUuwg3OkLKQSGXXeqHJIq,QcoNTf90utTM2XX2dus7Rk" />
+          <Link Id="FjgnQgievQBM7nIOLdTISS" Ids="MslgFpjUj16LXaCsLYXhHS,LFfXsKFENbVPIRCRe6kvYZ" />
           <Link Id="F8nvLrRBSM0OrcQOw34qLc" Ids="VoCDYGjSDHnOTyYRFbasVj,OT5JeJ2Ljw1MU1rEtQ6aO9" />
-          <Link Id="QQ0Osj9znkhLJ6TwjYxrZf" Ids="JnBgBKLJfitNkjXzurByy5,RDkdCDEUULJLw3V5je2P3B" />
-          <Link Id="FuCG4RPNtp2MXnVhBLQvmY" Ids="NXXcPv0XrdoL326xzz8rIc,GRcz8ewfi1ePGGymEItmvD" IsFeedback="true" />
-          <Link Id="PJ6VIrKmXN5NrCEoyGIlFJ" Ids="VVzNbsglL33O67sxEkPzHJ,GRcz8ewfi1ePGGymEItmvD" />
-          <Link Id="DcT8LOmHdjyMhNu9uayYVb" Ids="GRcz8ewfi1ePGGymEItmvD,E0ZlpdJwKtMPfL1JZZVjwp" />
-          <Link Id="J57hu46bhlKM3S9IbLWYle" Ids="HepEiKuRaFKM7PjVIzyVgh,SucSbJns5j6MtTTdL9AFI3" IsFeedback="true" />
-          <Link Id="HTgujKadvu2OMAyby0mfjL" Ids="VoCDYGjSDHnOTyYRFbasVj,SucSbJns5j6MtTTdL9AFI3" />
-          <Link Id="HECkwLupuJnNTO57NoyZ7Z" Ids="SucSbJns5j6MtTTdL9AFI3,RMOpHoE51oKM82IPZhdn0z" />
+          <Link Id="NyQNElx6XgMN9vQKeTc7T7" Ids="OVNonTeEUUELgdXirbHavb,NDqg11vVcIGN6LKo1YrF0M" />
+          <Link Id="GqiNkWSaNlSMano5o2SyQa" Ids="EbDN0YyyCVTLA1pF5Y0kzl,VSE105JSGHYLExsEVNA5uw" />
+          <Link Id="RQC4POlxPyrNvUjnnaKt2o" Ids="LYOspVrJDh6LQ4YyP2Xpn3,LIcIvJ6vtwoNlcZXJTtmte" />
+          <Link Id="QnKomcQYfbJN0xaEZYg2sY" Ids="BGcZoZ8cJ5SPF7eoiD0ici,QZbwOcgIZ2UNE8LED9EDOl" />
+          <Link Id="Ses4mQLC7NSN00jkBNmoyT" Ids="Iz8UQt2AyPkO4Q8YD2GtsJ,Cq7EI32JUf8MEL2gktno3I" />
+          <Link Id="GMKhF5WaAElMZ4KLLeyT8j" Ids="Hzzz4ZDd8sMMjg8IRE34vt,Ayhonw7NV1aOZCzWaNBjke" />
+          <Link Id="OauPBJbbuEZOmCLRpliwxy" Ids="Rw3WAAolAICQF69Uj0nQf3,Sr7tB3d11SSMPoKjaUOips" />
+          <Link Id="MrWxebtYZVWQGAyZlm5fSB" Ids="U4H2YUN9QCeNPboiBSEVfi,PuF4xC6hed3LlihRCRsD0Y" />
+          <Link Id="SCzz5qmF3sHQFnOSs7k2P4" Ids="SWNPIaIiQmfOtqyLRIO5S0,LpYp40AgEA3OY7FcrKZ4cO" />
+          <Link Id="HDjvScNa7w3OwnuwiZ5amq" Ids="Sh9CiOrQjgJMJ8q6m2Sswx,B8AwLZ5EYcNNeh16msL4MO" />
+          <Link Id="SCCc9dObNm6Ovpj3UlusIC" Ids="LlnVnudKvbDMQgBS93no2i,OtoBp0tHAizQbL5kqjQHW7" />
+          <Link Id="H8mBAQYRPKjQIYGSRhJWt1" Ids="SWNPIaIiQmfOtqyLRIO5S0,JnBgBKLJfitNkjXzurByy5" />
+          <Link Id="MUFBZlZkS7lMznbZG7uxys" Ids="JnBgBKLJfitNkjXzurByy5,RDkdCDEUULJLw3V5je2P3B" />
+          <Link Id="JtadHXAfLPOO9UeWtBjpLO" Ids="OtoBp0tHAizQbL5kqjQHW7,JjSzdFTAnigLlyFlXC63j8" />
+          <Link Id="J652q53wUCsLxVdhUK82xj" Ids="KsOqaihEpF8PoQKSspIZFO,RBnRkKTgpqJP4JIrTTY73k" />
+          <Link Id="EWpgrCigZ69MdUs3YnrB0J" Ids="SELaYz987gJPWnPmwbZclL,KsOqaihEpF8PoQKSspIZFO" IsHidden="true" />
+          <Link Id="A53GRicfZlsPaI8uoRTyzn" Ids="B8JepBlveYNPj5EfneExji,Gq9ho2e4fDxMvpGGU45du5" />
+          <Link Id="SBVmYABYDtDL7tzIMGLzpy" Ids="Gq9ho2e4fDxMvpGGU45du5,OdDouNds1VRPZnpOzlcANk" IsHidden="true" />
+          <Link Id="Ea3WIY73vjYOiTP1Wg0lm5" Ids="VVzNbsglL33O67sxEkPzHJ,E0ZlpdJwKtMPfL1JZZVjwp" />
+          <Link Id="UIl8keKAKA9QZdRbT55Ps3" Ids="E0ZlpdJwKtMPfL1JZZVjwp,Eypxf2jGavDNZkg5yTfufO" IsHidden="true" />
         </Patch>
       </Node>
     </Canvas>
@@ -453,23 +434,23 @@
       </p:NodeReference>
       <Patch Id="SFj9eB7SXcmPyN1Wmx0GSu">
         <Canvas Id="QgraeST4HawMgLODHXSk1L" CanvasType="Group">
-          <Node Bounds="163,251,65,19" Id="Tq90XQ5kWDBO2t7AKBTOx4">
+          <Node Bounds="269,411,65,19" Id="FbFB0RjCD4sLvbKqmS5ykS">
             <p:NodeReference LastCategoryFullName="HDE" LastDependency="VL.HDE.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Command" />
             </p:NodeReference>
-            <Pin Id="CbeyNBBxHWwOaVcUmixSiq" Name="Name" Kind="InputPin" />
-            <Pin Id="QLEwjH0yOWoMCLTjYFTOC3" Name="Visible" Kind="InputPin" />
-            <Pin Id="Ugiz9C52GPvMUOaexkiCGg" Name="Shortcut" Kind="InputPin" />
-            <Pin Id="FHpM5sWodcqPxTGcR9nkZj" Name="Enabled" Kind="InputPin" />
-            <Pin Id="EAmG1gJB1PRMGTKp2oa3DA" Name="On Execute" Kind="OutputPin" />
+            <Pin Id="H45tiBJu1BvMsWBUOCbUD7" Name="Name" Kind="InputPin" />
+            <Pin Id="LFUkfNNddgIQAjCm32uDTU" Name="Visible" Kind="InputPin" />
+            <Pin Id="HD45I5GYXH4L3zfYycd2Z5" Name="Shortcut" Kind="InputPin" />
+            <Pin Id="EYnzxEIyPLuPzLRdtKqYPL" Name="Enabled" Kind="InputPin" />
+            <Pin Id="QIMgDg9S2WhNdpX1ekN98E" Name="On Execute" Kind="OutputPin" />
           </Node>
-          <Pad Id="U4pPkv9MW9WLfBwSz94BuP" Comment="Label for menu entry" Bounds="165,67,40,15" ShowValueBox="true" isIOBox="true" Value="Pipette">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+          <Pad Id="CmKiit8HlmdOcSBlViimvh" Comment="Label for menu entry" Bounds="271,227,95,15" ShowValueBox="true" isIOBox="true" Value="Pipette">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="MJBv6s5KiIRLtRHMAnkzDc" Comment="Enabled" Bounds="225,231,35,35" ShowValueBox="true" isIOBox="true" Value="True">
+          <Pad Id="BLmWfbeNcxdPg2eZWjjWVo" Comment="Enabled" Bounds="331,391,35,15" ShowValueBox="true" isIOBox="true" Value="True">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Boolean" />
               <FullNameCategoryReference ID="Primitive" />
@@ -478,7 +459,7 @@
               <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Toggle</p:buttonmode>
             </p:ValueBoxSettings>
           </Pad>
-          <Pad Id="UD0xAokCbVaNQM8ZP5MlnO" Comment="Visibility of menu entry" Bounds="225,86,35,35" ShowValueBox="true" isIOBox="true" Value="True">
+          <Pad Id="DE6VLioJivnL4FUwZlBzyI" Comment="Visibility of menu entry" Bounds="291,270,35,15" ShowValueBox="true" isIOBox="true" Value="True">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Boolean" />
               <FullNameCategoryReference ID="Primitive" />
@@ -487,147 +468,561 @@
               <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Toggle</p:buttonmode>
             </p:ValueBoxSettings>
           </Pad>
-          <Pad Id="VpDw21gaHM0PP3YD3gb8Rk" Comment="Shortcut" Bounds="225,151,114,15" ShowValueBox="true" isIOBox="true" Value="Alt">
-            <p:TypeAnnotation LastCategoryFullName="IO.Keyboard" LastDependency="CoreLibBasics.vl">
+          <Pad Id="I481xOkdoytMb1SaTjNJJh" Comment="Shortcut" Bounds="311,309,120,15" ShowValueBox="true" isIOBox="true" Value="Alt">
+            <p:TypeAnnotation LastCategoryFullName="IO.Keyboard" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Keys" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="223,192,25,19" Id="J72xZVA3suHOacXmHMIwki">
-            <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastDependency="CoreLibBasics.vl">
+          <Node Bounds="269,469,65,19" Id="CmgrBOwVgF2P1z9EsmGKOA">
+            <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
+            </p:NodeReference>
+            <Pin Id="Lzd2fyBXBvJP4F4UUgDfBh" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Mwl0eOVViqyOfRo6AWbqJM" Name="Initial Result" Kind="InputPin" IsHidden="true" />
+            <Pin Id="L165Iak8JnROxsnD5outxu" Name="Async Notifications" Kind="InputPin" />
+            <Pin Id="MpD41609QbkOaIz8YDzaYX" Name="Reset" Kind="InputPin" />
+            <Pin Id="NOZ1k2ISs9pPnP9pD8oK6t" Name="Output" Kind="OutputPin" IsHidden="true" />
+            <Pin Id="CjYlgp5FQuhL9Vx0SXVFvs" Name="Value" Kind="OutputPin" />
+            <Pin Id="Mi69FKSBCjpLQ73dtE34pg" Name="On Data" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="329,552,52,19" Id="AQoaICmwLOUMEaXgJUoUBk">
+            <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="Toggle" />
+            </p:NodeReference>
+            <Pin Id="PQl9bIlQcoSNgODWybyKdz" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="CBAyFw77HAYOcLxbInZgbz" Name="Flip" Kind="InputPin" />
+            <Pin Id="FgYr4ihQocVNRIwa4s5386" Name="Reset" Kind="ApplyPin" />
+            <Pin Id="NXYglHukEEnN05fEkg1ZAg" Name="Value" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="309,350,25,19" Id="JwaoiqLYjfDPxahm8zH3pB">
+            <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="|" />
             </p:NodeReference>
-            <Pin Id="Qp3qTmRduBmNysqKAcsLcc" Name="Input" Kind="InputPin" />
-            <Pin Id="QsOy2NbuPtAQOE1nSGrksE" Name="Input 2" Kind="InputPin" />
-            <Pin Id="F3WEt9NnVLLQUCZFMvH8Cm" Name="Output" Kind="OutputPin" />
+            <Pin Id="Mn77De0zEdHOI9l5sBohmH" Name="Input" Kind="InputPin" />
+            <Pin Id="HlzSTnBUpRvQJytcMNCI4G" Name="Input 2" Kind="InputPin" />
+            <Pin Id="KB0YDR2Z0BALMj21rcdnD1" Name="Output" Kind="OutputPin" />
           </Node>
-          <Pad Id="TOjlw9h9oGqLsps0KfwcRO" Comment="Shortcut" Bounds="245,171,114,15" ShowValueBox="true" isIOBox="true" Value="P">
-            <p:TypeAnnotation LastCategoryFullName="IO.Keyboard" LastDependency="CoreLibBasics.vl">
+          <Pad Id="CanuygkQveGP9HZMCmzVDi" Comment="Shortcut" Bounds="331,329,120,15" ShowValueBox="true" isIOBox="true" Value="P">
+            <p:TypeAnnotation LastCategoryFullName="IO.Keyboard" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Keys" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="JyjHfNFi4nRLLDhPao51Yh" Comment="Name" Bounds="220,309,69,15" ShowValueBox="true" isIOBox="true">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+          <Node Bounds="933,410,264,616" Id="AOzBcBXlchzLfww7VwNz8H">
+            <p:NodeReference LastCategoryFullName="HDE" LastDependency="VL.HDE.vl">
+              <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="WindowFactory" />
+            </p:NodeReference>
+            <Pin Id="MNIXoRDdmtoPZv6OE8MR8R" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Kv994FjaMLsPMGVGRpg2KL" Name="Name" Kind="InputPin" />
+            <Pin Id="Vlg2VAIJpl4MBpMPZksMy7" Name="Output" Kind="StateOutputPin" />
+            <Pin Id="JeosVIzUJutOjr1eoJJ70u" Name="Active Window Count" Kind="OutputPin" />
+            <Patch Id="HkBcfA8nS0dLkzkKXgqNoi" ManuallySortedPins="true">
+              <Patch Id="NT7WnaWVi76LjuhsyZ7GeU" Name="Create" ManuallySortedPins="true">
+                <Pin Id="T3aVd32W6cIQPYb0mZAKMd" Name="Window Context" Kind="InputPin" />
+              </Patch>
+              <Patch Id="LoCczcYUpKUMdZT24Vfngc" Name="Update" ParticipatingElements="E9fRqtT8M7iPYJiUyEVfgN,M6a5Emg9GBWLGl0ZBeyG2Q" ManuallySortedPins="true">
+                <Pin Id="U12SozBCamSNP4cYEaMUoa" Name="Window" Kind="OutputPin" />
+              </Patch>
+              <ControlPoint Id="SPTZ07HP1FqQdd0wRh0qHk" Bounds="941,433" />
+              <ControlPoint Id="VOFmRxXz5SUPVzszZMLaqI" Bounds="947,761" />
+              <Node Bounds="1059,507,94,62" Id="U2zFBsflGNGOsPBlpPgNMG">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                </p:NodeReference>
+                <Pin Id="UlP2AcgiUSrNiXtJ0CVXHZ" Name="Condition" Kind="InputPin" />
+                <Patch Id="AAN2pn6ks8wP34VosUqWYr" ManuallySortedPins="true">
+                  <Patch Id="SrVVN7oSCDzL52Ug8QX0aN" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="IV29BgOaJV3L44xk5ru8XB" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="1071,530,68,19" Id="U4YTiewQYI6MAsjtiJnKw9">
+                    <p:NodeReference LastCategoryFullName="HDE" LastDependency="VL.Pipette.HDE.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="ProcessAppFlag" Name="Pipette" />
+                    </p:NodeReference>
+                    <Pin Id="LVVoBkTU8MdN2na1KVnybP" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                    <Pin Id="PsKd5xnlhkoPAUn9i7XwRx" Name="Input" Kind="InputPin" />
+                    <Pin Id="M9kNpFxduyzM3MzoAtdiPc" Name="Output" Kind="OutputPin" />
+                    <Pin Id="FGfBTWdp6u3QX7RD97hQ0h" Name="Result" Kind="OutputPin" />
+                  </Node>
+                </Patch>
+                <ControlPoint Id="Pbmr54Ssby6M83hJevBMDb" Bounds="1073,563" Alignment="Bottom" />
+                <ControlPoint Id="UgTaKnDm5gJPKrupvdcoXJ" Bounds="1084,513" Alignment="Top" />
+                <ControlPoint Id="PnvK7ErNvQfLQSOO6CwwxK" Bounds="1136,563" Alignment="Bottom" />
+                <ControlPoint Id="CjtLvLu5u4BLfFrIUeYrMw" Bounds="1136,513" Alignment="Top" />
+              </Node>
+              <Node Bounds="1065,433,69,19" Id="LWnMxZp1bcEOuPPrHpynV2">
+                <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="FrameDelay" />
+                </p:NodeReference>
+                <Pin Id="Fw4Sg7uOP1mOEXWh03sKZC" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                <Pin Id="K5wiEjkz9EOOu63iTp04NR" Name="Initial Value" Kind="InputPin" IsHidden="true" />
+                <Pin Id="L2mk1DMjnEvM78vMrgH2KK" Name="Value" Kind="InputPin" />
+                <Pin Id="MyjTYF5KwJyNwGJLOEYW4M" Name="Value" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="1053,463,65,19" Id="IT4U840YmhwPANB3Tr6wqt">
+                <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="IsAssigned" />
+                </p:NodeReference>
+                <Pin Id="CRIQs1VeFKOL6uEdvF0wbC" Name="X" Kind="InputPin" />
+                <Pin Id="R9jCJyog9gTNyGnWJhyyAU" Name="Result" Kind="OutputPin" />
+                <Pin Id="CEDM1wjwO2HPxihiUvQfK1" Name="Not Assigned" Kind="OutputPin" />
+              </Node>
+              <Pad Id="OCdKKuEUwhoN94NvX5q5LB" Comment="" Bounds="1035,583,27,28" ShowValueBox="true" isIOBox="true" Value="250, 250">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Int2" />
+                </p:TypeAnnotation>
+              </Pad>
+              <Pad Id="DsCCwiThA7PObNEJo6RaFj" Comment="Window Context" Bounds="950,471" isIOBox="true" />
+              <Node Bounds="1053,714,131,292" Id="CY5hR6wqIk5LYDM0VQpuRV">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                </p:NodeReference>
+                <Pin Id="FjZVj1gryRYN9pkJSgZ3Jn" Name="Condition" Kind="InputPin" />
+                <Patch Id="UWubIlchgdiPTk1QMhtI7e" ManuallySortedPins="true">
+                  <Patch Id="PFbetOQkhq0P9jqqGQB18c" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="QGWwBMlmgowMWRejJTDbjQ" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="1097,734,71,75" Id="Dey2kwzA8I9LtqIBfeM5rS">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                      <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                      <CategoryReference Kind="Category" Name="Primitive" />
+                      <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                    </p:NodeReference>
+                    <Pin Id="NIUZHcmS6PxOQsDjVrWkqO" Name="Force" Kind="InputPin" />
+                    <Pin Id="MABtu27A3rNOPpwRW6XfaI" Name="Dispose Cached Outputs" Kind="InputPin" />
+                    <Pin Id="IYS66QKscZFNv0g0vDiPWT" Name="Has Changed" Kind="OutputPin" />
+                    <Patch Id="VCEQgDePhf0P1p8rWNhMFv" ManuallySortedPins="true">
+                      <Patch Id="BHonvFtLDhsP08RdgutfmV" Name="Create" ManuallySortedPins="true" />
+                      <Patch Id="CZAySn3Dbs2L0UcCfd5v3y" Name="Then" ManuallySortedPins="true" />
+                      <Node Bounds="1109,763,47,26" Id="J5NYoBB3E53QHebS8uZW1H">
+                        <p:NodeReference LastCategoryFullName="System.Windows.Forms.Form" LastDependency="System.Windows.Forms.dll">
+                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                          <FullNameCategoryReference ID="System.Windows.Forms.Form" />
+                          <Choice Kind="OperationCallFlag" Name="Closed" />
+                        </p:NodeReference>
+                        <Pin Id="RxT2QJuV6iFNGm4KKeCH5J" Name="Input" Kind="StateInputPin" />
+                        <Pin Id="Jk5Eey3IpdqPTDJ6LYgUaf" Name="State Output" Kind="OutputPin" IsHidden="true" />
+                        <Pin Id="OpQYtlqJJ2QLmrxDEFsxeQ" Name="Result" Kind="OutputPin" />
+                      </Node>
+                    </Patch>
+                    <ControlPoint Id="HwnbkvfAz5eMwRLIzweI72" Bounds="1111,740" Alignment="Top" />
+                    <ControlPoint Id="B8xrpJGf5zGOvbLvpsYZaY" Bounds="1110,803" Alignment="Bottom" />
+                  </Node>
+                  <Node Bounds="1108,820,65,19" Id="SzeQsFPRuoSPJSADhmVsfr">
+                    <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
+                    </p:NodeReference>
+                    <Pin Id="ODz9IJVpjR4MVL1NXmg4pT" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                    <Pin Id="JE33SIR2IocO19INyr8MZf" Name="Initial Result" Kind="InputPin" IsHidden="true" />
+                    <Pin Id="NxTgYpQ8r8VOMtSEPWNiOi" Name="Async Notifications" Kind="InputPin" />
+                    <Pin Id="D7iZ7TWePToLuMRdhtxll8" Name="Reset" Kind="InputPin" />
+                    <Pin Id="HO6iVkebHaTLi7IIjXNWdJ" Name="Output" Kind="OutputPin" IsHidden="true" />
+                    <Pin Id="Ffcm2NjRIruOYUS8AewXLv" Name="Value" Kind="OutputPin" />
+                    <Pin Id="MWzZQDXJLkePFwXQOqcKju" Name="On Data" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="1074,960,55,26" Id="ME1xL2TdLJtP2oCDoLW9aw">
+                    <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="MutableInterfaceType" Name="Channel" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="SetValue" />
+                    </p:NodeReference>
+                    <Pin Id="Cd0V0l8miJmLvJsecsWDoa" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="TgV9wdnb0tgO7rRt3PfXIp" Name="Value" Kind="InputPin" DefaultValue="True" />
+                    <Pin Id="P8YIQssBxZ7LpN6WtV67Dd" Name="Author" Kind="InputPin" IsHidden="true" />
+                    <Pin Id="Gf9zGFH0ZjyN8EybWrYsmE" Name="Apply" Kind="InputPin" />
+                    <Pin Id="JRAsxIczerBM9RBK8hoT3l" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <Node Bounds="1108,860,62,26" Id="BT98PxvovyhNw6vjEytONf">
+                    <p:NodeReference LastCategoryFullName="Reactive.EventPattern" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <FullNameCategoryReference ID="Reactive.EventPattern" />
+                      <Choice Kind="OperationCallFlag" Name="EventArgs" />
+                    </p:NodeReference>
+                    <Pin Id="Qicp6ZNUAyhMvgo6f7BPOF" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="IPmPTJA561wPzaGbDDNuzZ" Name="Event Args" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="1108,920,37,19" Id="US4pW3gV9DfNUaXRzCyqLz">
+                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="NOT" />
+                    </p:NodeReference>
+                    <Pin Id="Qv208sfboQ3M0L3lYzbX4z" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="MDd0ArB9xb3Mv47wvmmzLj" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <Node Bounds="1108,890,48,19" Id="OUcm7db1rrDNNozzZkiI3g">
+                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="CastAs" />
+                    </p:NodeReference>
+                    <Pin Id="CBgNPoWUn0ZNsFk1iyTFkh" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="RiYvcX0WYLRP5KmSdbBRx6" Name="Default" Kind="InputPin" />
+                    <Pin Id="LnQecV2iucfOwOOoZlrtU1" Name="Result" Kind="OutputPin" />
+                    <Pin Id="Sy0kYDlF14dLCgpLqrI3Rt" Name="Success" Kind="OutputPin" />
+                  </Node>
+                </Patch>
+              </Node>
+              <Node Bounds="945,630,225,19" Id="QHdAbtH8ViGL7I7vHnit1p">
+                <p:NodeReference LastCategoryFullName="HDE" LastDependency="VL.HDE.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="SkiaWindow" />
+                </p:NodeReference>
+                <Pin Id="JOoDoqYZQ6FNMsTj55RyQV" Name="Window Context" Kind="InputPin" />
+                <Pin Id="EOkjIDSSN7WLlfHwo4lAuN" Name="Show Hint" Kind="InputPin" />
+                <Pin Id="MEW1vs8mkadNgWNwpiID17" Name="Location" Kind="InputPin" />
+                <Pin Id="M2AZ32j1BFIOtivBi9OzJW" Name="Size" Kind="InputPin" />
+                <Pin Id="S56Y9AiYspLOLvkAeZtlOD" Name="Input" Kind="InputPin" />
+                <Pin Id="CHYhDOwYTd2OwQD9GGuQph" Name="Name" Kind="InputPin" />
+                <Pin Id="PJpQYPgA367MV3sxrog8SV" Name="Color" Kind="InputPin" />
+                <Pin Id="KR4IxdEvthqPZEuqqAkCJ9" Name="Space" Kind="InputPin" />
+                <Pin Id="Q5AlbwOTiuUNXYogi9JHQX" Name="Output" Kind="OutputPin" />
+              </Node>
+            </Patch>
+          </Node>
+          <Pad Id="E6NihScrkiWN4dgWTzGGnC" Comment="Name" Bounds="1098,321,72,15" ShowValueBox="true" isIOBox="true" Value="Pipette">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="161,501,108,95" Id="LagMnBWFuPUP6WFEFVhYNs">
+          <Node Bounds="1076,250,53,19" Id="NVR5bngYOJ8N23lG4jAg2w">
+            <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="Channel" />
+            </p:NodeReference>
+            <Pin Id="EcPUASot6fHMs96tPu8j4R" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="JJQWkKqJab2Pn3vgL3m1hU" Name="Initial Value" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Fwqm5TPBDB8PXVVETHHGTv" Name="Value" Kind="InputPin" />
+            <Pin Id="GEPfdbmOumKOf3PnHb1bLK" Name="Output" Kind="OutputPin" />
+            <Pin Id="SHWhlBf3vboQXvSy2DloyW" Name="Value" Kind="OutputPin" />
+            <Pin Id="U7clktUEQALNmP84UYdHBL" Name="Author" Kind="InputPin" IsHidden="true" />
+          </Node>
+          <Node Bounds="376,470,56,19" Id="N9kKBWKIA3TLpi6oSZcBjq">
+            <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="TogEdge" />
+            </p:NodeReference>
+            <Pin Id="QhOvM8nEQ4lNtu3QW6iBkZ" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="RwHYRf5xvhsOpfW2prXx73" Name="Value" Kind="InputPin" />
+            <Pin Id="McviIEOUzPdP8SG8tqyieq" Name="Up Edge" Kind="OutputPin" />
+            <Pin Id="H05lG5NfhhVNaUGMmCFdlL" Name="Down Edge" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="188,832,575,691" Id="VCmfgB0OeKvM8DCI6EeuCz">
+            <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+              <CategoryReference Kind="Category" Name="Control" />
+              <Choice Kind="ProcessAppFlag" Name="Comment" />
+            </p:NodeReference>
+            <Patch Id="E7d00Zp5yYFNgR6BqB03ir" ManuallySortedPins="true">
+              <Patch Id="HNslZ3hcEVXNp1UJ9RFRAC" Name="Create" ManuallySortedPins="true" />
+              <Patch Id="P6Lj79ozGTTNED2g4dmFE5" Name="Update" ManuallySortedPins="true" />
+              <Patch Id="NeydlpnXsVsNfIRmBWW3VT" Name="Dispose" ManuallySortedPins="true" />
+              <Pad Id="JpgALS84bihMJHrds6SuEI" Comment="Active" Bounds="269,860,35,35" ShowValueBox="true" isIOBox="true" />
+              <Node Bounds="235,876,516,446" Id="Hx0y90kaVb6PMnsEX2kHjM">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <Choice Kind="ApplicationStatefulRegion" Name="Repeat" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                </p:NodeReference>
+                <Pin Id="QfZ9m6IY1YqNZgJf6NsMOm" Name="Iteration Count" Kind="InputPin" />
+                <Pin Id="LlZTJ5eZLOEPAUBAdUu4NU" Name="Break" Kind="OutputPin" />
+                <Patch Id="OzVS1i2qxGGOrKXYxDEqAL" ManuallySortedPins="true">
+                  <Patch Id="TQjBSC3qZQpP1Ym0ziiJSU" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="FWa5QwAENXiNEngblqgkV0" Name="Update" ManuallySortedPins="true" />
+                  <Patch Id="Nvgt2ZZVIaYM21HyHDAhYB" Name="Dispose" ManuallySortedPins="true" />
+                  <Node Bounds="247,1103,225,19" Id="L5Mr90wtjYXQIRFRcvjM9W">
+                    <p:NodeReference LastCategoryFullName="HDE" LastDependency="VL.HDE.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="ProcessAppFlag" Name="SkiaWindow" />
+                    </p:NodeReference>
+                    <Pin Id="LPBwIRnjuzBOFjaWL25IMu" Name="Window Context" Kind="InputPin" />
+                    <Pin Id="QYLJICX89ObPNyFV6zA3hR" Name="Show Hint" Kind="InputPin" />
+                    <Pin Id="TtnxPRio4zRNGQNXCWQmvL" Name="Location" Kind="InputPin" />
+                    <Pin Id="IHMhiaM7lQlMcLvxUKHpPV" Name="Size" Kind="InputPin" />
+                    <Pin Id="DmC8Qzc9yhGO6w7NCHmVUR" Name="Input" Kind="InputPin" />
+                    <Pin Id="E2AaVzokvJfPMhc04pIc1U" Name="Name" Kind="InputPin" />
+                    <Pin Id="OfWdRkJ82vYPlp3jKis5ys" Name="Color" Kind="InputPin" />
+                    <Pin Id="SOB1ZLr2w6dL7Hn7G5XsbC" Name="Space" Kind="InputPin" />
+                    <Pin Id="NcZDXn3Cj1jP6qhOGTJb7H" Name="Output" Kind="OutputPin" />
+                  </Node>
+                  <Pad Id="JsqR4qf5AozMRoTiXFimq3" Comment="Name" Bounds="406,904,72,15" ShowValueBox="true" isIOBox="true" Value="Pipette">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="TypeFlag" Name="String" />
+                    </p:TypeAnnotation>
+                  </Pad>
+                  <Node Bounds="247,1133,69,19" Id="NDemdvIS7UzONo6K82fhSw">
+                    <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="ProcessAppFlag" Name="FrameDelay" />
+                    </p:NodeReference>
+                    <Pin Id="HHUvpz2WmfiNSkuNqutOlI" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                    <Pin Id="Uw4EruIIuuqMmXalFebMVb" Name="Initial Value" Kind="InputPin" IsHidden="true" />
+                    <Pin Id="QNyVJDfoU5cPV2ojmnM2YU" Name="Value" Kind="InputPin" />
+                    <Pin Id="GZ5IGD7wAQYOq8IH2tKd8Y" Name="Value" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="489,983,65,19" Id="Pii425JpjZEL9qkgKkBfmK">
+                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="IsAssigned" />
+                    </p:NodeReference>
+                    <Pin Id="F9xMiDoXOEsM55Ii6A5C7M" Name="X" Kind="InputPin" />
+                    <Pin Id="Fkl7y2BolsBM34faKq7oYb" Name="Result" Kind="OutputPin" />
+                    <Pin Id="HSoouplXN2BL6Wjzp06iZf" Name="Not Assigned" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="361,1021,94,71" Id="LQcRlDYhl5TP0f8eQNgoYD">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                      <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                      <CategoryReference Kind="Category" Name="Primitive" />
+                      <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                    </p:NodeReference>
+                    <Pin Id="A3W2rl3OO1ZPqDNhySe0CB" Name="Condition" Kind="InputPin" />
+                    <Patch Id="EKSBReYNXsoP2qfH6M0MKt" ManuallySortedPins="true">
+                      <Patch Id="JJCikOklcayOoNjtzdkfPm" Name="Create" ManuallySortedPins="true" />
+                      <Patch Id="P8j2roRcoHAOK9WuEebrcW" Name="Then" ManuallySortedPins="true" />
+                      <Node Bounds="373,1053,68,19" Id="SRdomAyf5HHOitSplwExNc">
+                        <p:NodeReference LastCategoryFullName="HDE" LastDependency="VL.Pipette.HDE.vl">
+                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                          <Choice Kind="ProcessAppFlag" Name="Pipette" />
+                        </p:NodeReference>
+                        <Pin Id="PlBqsalIdACMlMHvd2EHcT" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                        <Pin Id="M9nam8gLwQGPpMKUNSoAeO" Name="Input" Kind="InputPin" />
+                        <Pin Id="OC3QBXtubAaLzWkbVsDnOR" Name="Output" Kind="OutputPin" />
+                        <Pin Id="RO9elGolHJmLm0s8XfCDbF" Name="Result" Kind="OutputPin" />
+                      </Node>
+                    </Patch>
+                    <ControlPoint Id="Pqv33ctMY8wMffIWrE09ji" Bounds="375,1086" Alignment="Bottom" />
+                    <ControlPoint Id="SVmCTVDZBb0OPUUnAQ2Jzg" Bounds="375,1027" Alignment="Top" />
+                    <ControlPoint Id="RqWlAUMF60oMrKIQL2akA5" Bounds="438,1086" Alignment="Bottom" />
+                    <ControlPoint Id="LsJfWN6N2gcP5i7KV6s4NY" Bounds="438,1027" Alignment="Top" />
+                  </Node>
+                  <Pad Id="H6ynv7symjkMRCDXubfuqY" Comment="" Bounds="491,963" isIOBox="true" />
+                  <Node Bounds="489,1138,127,115" Id="UZfKV25iaDkM1ChfrfoW2D">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                      <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                      <CategoryReference Kind="Category" Name="Primitive" />
+                      <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                    </p:NodeReference>
+                    <Pin Id="GtsFep2ERP7NgubNlFV06A" Name="Condition" Kind="InputPin" />
+                    <Patch Id="O1zDOPeKxwyN7f1Y6S6yHW" ManuallySortedPins="true">
+                      <Patch Id="MgagIL8GSgRNEzAHAOFfqh" Name="Create" ManuallySortedPins="true" />
+                      <Patch Id="KUWKM7MJekDPvM43OYy7N2" Name="Then" ManuallySortedPins="true" />
+                      <Node Bounds="533,1158,71,75" Id="MRucmWJBjjBOBtZU3N1BSY">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                          <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                          <CategoryReference Kind="Category" Name="Primitive" />
+                          <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                        </p:NodeReference>
+                        <Pin Id="FZw79Mouf3sMHgdIitXKC3" Name="Force" Kind="InputPin" />
+                        <Pin Id="RTSGWUsQ3NEMl6TxZKASmt" Name="Dispose Cached Outputs" Kind="InputPin" />
+                        <Pin Id="MxNaZZV8EPCOQCafgVh7M0" Name="Has Changed" Kind="OutputPin" />
+                        <Patch Id="NnKZG8fgdJ1MJ1xTczC4KM" ManuallySortedPins="true">
+                          <Patch Id="PnC15fL1kLpMfrTLdCVquO" Name="Create" ManuallySortedPins="true" />
+                          <Patch Id="ViWLPjtKjFmMAdKRjzAmm4" Name="Then" ManuallySortedPins="true" />
+                          <Node Bounds="545,1187,47,26" Id="VehrsI17Y1UNgy1c0q9ZbL">
+                            <p:NodeReference LastCategoryFullName="System.Windows.Forms.Form" LastDependency="System.Windows.Forms.dll">
+                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                              <FullNameCategoryReference ID="System.Windows.Forms.Form" />
+                              <Choice Kind="OperationCallFlag" Name="Closed" />
+                            </p:NodeReference>
+                            <Pin Id="Iq9d9hMYWBTMqNbUdOTEiJ" Name="Input" Kind="StateInputPin" />
+                            <Pin Id="Plrw7atNN6nMHxapiwZJxC" Name="State Output" Kind="OutputPin" IsHidden="true" />
+                            <Pin Id="BZg6h6ve2F1L6em4PDp6La" Name="Result" Kind="OutputPin" />
+                          </Node>
+                        </Patch>
+                        <ControlPoint Id="JFfrlNcNvhVPRNgdPjxhNe" Bounds="547,1164" Alignment="Top" />
+                        <ControlPoint Id="LmftNs7PPbCQOEFajuaWQS" Bounds="546,1227" Alignment="Bottom" />
+                      </Node>
+                    </Patch>
+                    <ControlPoint Id="AYcW1OvSOI4NpH4HDY1Sd2" Bounds="546,1247" Alignment="Bottom" />
+                    <ControlPoint Id="F9sNuFQYz9PNzgUzbPUrXT" Bounds="546,1144" Alignment="Top" />
+                  </Node>
+                </Patch>
+                <ControlPoint Id="NiNrGsQmzdrMC7KgXUusdn" Bounds="500,1316" Alignment="Bottom" />
+                <ControlPoint Id="Q1fLPopUEpYOowKAiPnvIQ" Bounds="512,882" Alignment="Top" />
+                <ControlPoint Id="InsmNdQnS0BM9IxcdEcLpz" Bounds="734,1316" Alignment="Bottom" />
+                <ControlPoint Id="OKxlm3NmllCM8mHdqgC9Se" Bounds="734,882" Alignment="Top" />
+                <ControlPoint Id="BOaewLL7ypWPVE8GDdi1Qn" Bounds="674,1316" Alignment="Bottom" />
+                <ControlPoint Id="AFIQU4olKDIMVPzmkyps37" Bounds="674,882" Alignment="Top" />
+              </Node>
+              <Pad Id="IYkc47Ip2GhQNxJnkZD0xR" Comment="Size" Bounds="343,883,35,28" ShowValueBox="true" isIOBox="true" Value="250, 250">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Int2" />
+                </p:TypeAnnotation>
+              </Pad>
+              <Node Bounds="660,1393,65,19" Id="CmrjESrThaaOpxbDphFf0H">
+                <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="IsAssigned" />
+                </p:NodeReference>
+                <Pin Id="I5UahQXCTinMFXPFh2wl8U" Name="X" Kind="InputPin" />
+                <Pin Id="KW4K0rpgRw5QPOJ2TXJBiE" Name="Result" Kind="OutputPin" />
+                <Pin Id="DRP0rULtKbGPu5YrPl9WYL" Name="Not Assigned" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="660,1423,91,80" Id="Gcs16rhlTrQMCTuxpV95Og">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                </p:NodeReference>
+                <Pin Id="Acv4PtAk0vYLYSUhVyHZut" Name="Condition" Kind="InputPin" />
+                <Patch Id="Awbglt4OUZ0OXMzIV6MGaJ" ManuallySortedPins="true">
+                  <Patch Id="UI23PSyhFZON81UQxbtpvD" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="DhyPyeOfr3dPBGZ82zadbV" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="672,1455,65,19" Id="MronHB20ocCOhv72PlhaTF">
+                    <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
+                    </p:NodeReference>
+                    <Pin Id="KFQnBPX0dAjOlmFOnPuQW7" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                    <Pin Id="I6mKo7TYhHJMgPedDPpOUv" Name="Initial Result" Kind="InputPin" IsHidden="true" />
+                    <Pin Id="GGNyv50dpXXLtpZAa6G15e" Name="Async Notifications" Kind="InputPin" />
+                    <Pin Id="BiVrJkhkhGdLDDEaiZqobK" Name="Reset" Kind="InputPin" />
+                    <Pin Id="PyQN4ckhZwOLDLr7V6zzqT" Name="Output" Kind="OutputPin" IsHidden="true" />
+                    <Pin Id="ENeIGQvh2Y7Nd7ugEjIOeB" Name="Value" Kind="OutputPin" />
+                    <Pin Id="HPsti5cPXgFMFUJYdKrbO7" Name="On Data" Kind="OutputPin" />
+                  </Node>
+                </Patch>
+                <ControlPoint Id="F2fSQryFcqXN2eNz2gZ3x8" Bounds="734,1497" Alignment="Bottom" />
+                <ControlPoint Id="Sr1fwpjHDkyOhTQqA3m2Sw" Bounds="734,1429" Alignment="Top" />
+              </Node>
+              <Node Bounds="672,1353,69,19" Id="ONModcnIUQsOXnth9sj2XS">
+                <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="FrameDelay" />
+                </p:NodeReference>
+                <Pin Id="HCKphL4PtyPNGbH6Wphuk0" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                <Pin Id="CXejPUYZpE7Lys5HF1Su0T" Name="Initial Value" Kind="InputPin" IsHidden="true" />
+                <Pin Id="C3plj8tC09xLsKKgrsHqKG" Name="Value" Kind="InputPin" />
+                <Pin Id="MTj3z03XouPMomVxzKVx5D" Name="Value" Kind="OutputPin" />
+              </Node>
+            </Patch>
+            <Pin Id="TpFkokd7aefL44a6kwJiEO" Name="Node Context" Kind="InputPin" IsHidden="true" />
+          </Node>
+          <Node Bounds="868,1040,130,95" Id="TjoQKGgobSHMtrnCOvTfoL">
             <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
               <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
               <Choice Kind="ProcessAppFlag" Name="ForEach" />
             </p:NodeReference>
-            <Pin Id="ISvwSrBuvskNODKLlOFkjT" Name="Node Context" Kind="InputPin" IsHidden="true" />
-            <Pin Id="HygUu8cgJ3QNxNU4SljBp4" Name="Messages" Kind="InputPin" />
-            <Pin Id="THaCQZRe3rFMDieknupWpB" Name="Reset" Kind="InputPin" />
-            <Pin Id="I9FuixqwnyXO7qv91SaGmI" Name="Result" Kind="OutputPin" />
-            <Patch Id="J0DzzWGYna7N5fGqb4W43Y" ManuallySortedPins="true">
-              <Patch Id="JkQTglivmZcLepydCAsQqu" Name="Create" ManuallySortedPins="true" />
-              <Patch Id="S4LzdiCoSfcL9uhDz9qId2" Name="Update" ManuallySortedPins="true">
-                <Pin Id="IdB6B80OpdVPg1KG66p0VS" Name="Input 1" Kind="InputPin" />
-                <Pin Id="HXxibJuTAN1LZkrKt97hwY" Name="Output" Kind="OutputPin" />
+            <Pin Id="O0Cvdzg98HsOq61YWVYwXU" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="DiI9wIqhGAVMdFTo1KEfUe" Name="Messages" Kind="InputPin" />
+            <Pin Id="G6zdzoVAYBhPAlJ3tky6yA" Name="Reset" Kind="InputPin" />
+            <Pin Id="MY7mFeVbrfcLHW2y3xNGAO" Name="Output" Kind="OutputPin" IsHidden="true" />
+            <Pin Id="ETrl7JunBa2OgbgHc1IFmG" Name="Result" Kind="OutputPin" />
+            <Patch Id="SAcNadGDx1HMHvazSKXsAM" ManuallySortedPins="true">
+              <Patch Id="IWPkV6sIqM3Laa93KJC5Ww" Name="Create" ManuallySortedPins="true" />
+              <Patch Id="CEhYobDcfHqO7olSJhHn7Y" Name="Update" ManuallySortedPins="true">
+                <Pin Id="Ml31fnQmpeyNcXezuwK9hB" Name="Input 1" Kind="InputPin" />
+                <Pin Id="BajTMx5SUO1LwD69uRGAdv" Name="Output" Kind="OutputPin" />
               </Patch>
-              <ControlPoint Id="HBrOmQ1KFbvOJgPk3GBERd" Bounds="165,509" />
-              <ControlPoint Id="N36BpizWwjPLAsAjJeBsgu" Bounds="165,589" />
-              <Node Bounds="175,536,82,26" Id="Oe3TwxClfi6LvHzMXzmBF7">
+              <ControlPoint Id="DSuyMzoWmNYLdgymWlrFfl" Bounds="872,1048" />
+              <ControlPoint Id="MWADKiG6mipMsMxeXQfMwr" Bounds="872,1128" />
+              <Node Bounds="904,1073,82,26" Id="EDR96m2iICXL7v2RT1szo5">
                 <p:NodeReference LastCategoryFullName="HDE.WindowFactory" LastDependency="VL.HDE.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <FullNameCategoryReference ID="HDE.WindowFactory" />
                   <Choice Kind="OperationCallFlag" Name="EnsureWindow" />
                 </p:NodeReference>
-                <Pin Id="C7oRnlOVVMtPWhyGrEK1KX" Name="Input" Kind="StateInputPin" />
-                <Pin Id="AxkJOBprz3XQCCdbx1OlAU" Name="Output" Kind="StateOutputPin" />
-              </Node>
-            </Patch>
-          </Node>
-          <Node Bounds="218,339,303,130" Id="Tx2ZByNrV5yL0JfJXOTkxa">
-            <p:NodeReference LastCategoryFullName="HDE" LastDependency="VL.HDE.vl">
-              <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-              <Choice Kind="ProcessAppFlag" Name="WindowFactory" />
-            </p:NodeReference>
-            <Pin Id="P42Ekc0ebQzMBsC7ypR69S" Name="Node Context" Kind="InputPin" IsHidden="true" />
-            <Pin Id="SaIrlKKNJ3XLftihnDR2TW" Name="Name" Kind="InputPin" />
-            <Pin Id="OTEpIeY0P3bPBQFzxTnBM7" Name="Output" Kind="StateOutputPin" />
-            <Pin Id="JJdP2qJxbIcPLpzLXQOr2R" Name="Active Window Count" Kind="OutputPin" />
-            <Patch Id="R70z6ZxYeO8O95J9THX8Ww" ManuallySortedPins="true">
-              <Patch Id="UgOuQaGm5zZOXu7QEeK2rM" Name="Create" ManuallySortedPins="true">
-                <Pin Id="LhrFItf1N5bQT5deF9Qc8O" Name="Window Context" Kind="InputPin" />
-              </Patch>
-              <Patch Id="OnUY37MDFJFM3OfdJyuDvS" Name="Update" ParticipatingElements="Pzt6HalXz3NPDwexFiXIyK,TVqDaH7nWaPQUwuPh7ZMOK,J1R2dioOpOsP0yQq0hqUvB" ManuallySortedPins="true">
-                <Pin Id="FpRyKntfa7cNQU4nGkrxGP" Name="Window" Kind="OutputPin" />
-              </Patch>
-              <ControlPoint Id="Jc78mjHkDsnMwEhZMtkEqP" Bounds="232,347" />
-              <ControlPoint Id="GUKDl02sYCnN4qhqnrPUW0" Bounds="232,462" />
-              <Node Bounds="230,416,185,19" Id="TMMy7TPzFewNopfmUSfNrU">
-                <p:NodeReference LastCategoryFullName="HDE" LastDependency="VL.HDE.vl">
-                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <Choice Kind="ProcessAppFlag" Name="SkiaWindow" />
-                </p:NodeReference>
-                <Pin Id="GaQs7vYj3t2O2qKvAuOicy" Name="Window Context" Kind="InputPin" />
-                <Pin Id="UTTHGPTPeD6N5etaf4XDY1" Name="Show Hint" Kind="InputPin" />
-                <Pin Id="PDgOHLaEek6OKFYGYqSNST" Name="Input" Kind="InputPin" />
-                <Pin Id="TYcaKu12KbzMwmS57QZCZ6" Name="Name" Kind="InputPin" />
-                <Pin Id="MFxpx7daCcfOlphX7JibpL" Name="Color" Kind="InputPin" />
-                <Pin Id="TsiuKLQm3arPpfLAW5WDWc" Name="Space" Kind="InputPin" />
-                <Pin Id="QbL2ksWUWXlQSMuNnDdXhZ" Name="Output" Kind="OutputPin" />
-              </Node>
-              <Node Bounds="302,377,48,19" Id="SRdomAyf5HHOitSplwExNc">
-                <p:NodeReference LastCategoryFullName="HDE" LastDependency="VL.Pipette.HDE.vl">
-                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <Choice Kind="ProcessAppFlag" Name="Pipette" />
-                </p:NodeReference>
-                <Pin Id="PlBqsalIdACMlMHvd2EHcT" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                <Pin Id="M9nam8gLwQGPpMKUNSoAeO" Name="Input" Kind="InputPin" />
-                <Pin Id="OC3QBXtubAaLzWkbVsDnOR" Name="Output" Kind="OutputPin" />
-                <Pin Id="RO9elGolHJmLm0s8XfCDbF" Name="Result" Kind="OutputPin" />
-              </Node>
-              <Node Bounds="440,419,69,19" Id="QTXGYYKPUDbM49o3gTq2aR">
-                <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
-                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <Choice Kind="ProcessAppFlag" Name="FrameDelay" />
-                </p:NodeReference>
-                <Pin Id="J7t6OCw1npiNKciUJHSk6s" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                <Pin Id="RxADOHknV9MNIBv3wtVnL5" Name="Initial Value" Kind="InputPin" IsHidden="true" />
-                <Pin Id="NdoVzjnKgHQOqfdKJ7yNSG" Name="Value" Kind="InputPin" />
-                <Pin Id="NZTZcrBZ353NlKSolQM2OY" Name="Value" Kind="OutputPin" />
+                <Pin Id="PK6JjpBzrEENsGPzhGokp0" Name="Input" Kind="StateInputPin" />
+                <Pin Id="Dq5QbXuUDAUNO6nVnZgT2S" Name="Output" Kind="StateOutputPin" />
+                <Pin Id="LnbtUZ2qAkYM8JKUXyY0uP" Name="Apply" Kind="InputPin" />
               </Node>
             </Patch>
           </Node>
         </Canvas>
         <Patch Id="DDbwxJRi07LO5KSRZgs7jl" Name="Create" />
-        <Patch Id="DjhaZ9pNxPaMWEC3nsUIfP" Name="Update" ParticipatingElements="GKiNrEK3bVgMiggYeMNZFr" />
+        <Patch Id="DjhaZ9pNxPaMWEC3nsUIfP" Name="Update" />
         <ProcessDefinition Id="HNiryMNglmxLybpjr8G1Fc">
           <Fragment Id="PVqz1vn3HCZPTkcwRlotlc" Patch="DDbwxJRi07LO5KSRZgs7jl" Enabled="true" />
           <Fragment Id="IpKp4kiQFfYOxAHtUm3hUa" Patch="DjhaZ9pNxPaMWEC3nsUIfP" Enabled="true" />
         </ProcessDefinition>
-        <Link Id="ItiQhJZJPn1QUK8GmuLJWK" Ids="U4pPkv9MW9WLfBwSz94BuP,CbeyNBBxHWwOaVcUmixSiq" />
-        <Link Id="ToXKpv0R469Mu4HZNATWYi" Ids="MJBv6s5KiIRLtRHMAnkzDc,FHpM5sWodcqPxTGcR9nkZj" />
-        <Link Id="DMScSFucNySNjEWyTOEJFp" Ids="UD0xAokCbVaNQM8ZP5MlnO,QLEwjH0yOWoMCLTjYFTOC3" />
-        <Link Id="I2RkHkgpY1cQLvQBKI4a0Q" Ids="VpDw21gaHM0PP3YD3gb8Rk,Qp3qTmRduBmNysqKAcsLcc" />
-        <Link Id="CDLOkpKkUbMMx4rWpMi76B" Ids="TOjlw9h9oGqLsps0KfwcRO,QsOy2NbuPtAQOE1nSGrksE" />
-        <Link Id="CYa8sBIJEAeNKHJBoSIGQy" Ids="F3WEt9NnVLLQUCZFMvH8Cm,Ugiz9C52GPvMUOaexkiCGg" />
-        <Link Id="DqADjjOKOCqQFf0HXNnHA6" Ids="IdB6B80OpdVPg1KG66p0VS,HBrOmQ1KFbvOJgPk3GBERd" IsHidden="true" />
-        <Link Id="UrCIaXoSk2aQNfD7uQRmdA" Ids="N36BpizWwjPLAsAjJeBsgu,HXxibJuTAN1LZkrKt97hwY" IsHidden="true" />
-        <Link Id="RV4PRlrZgDLPGVjsfkGoPz" Ids="EAmG1gJB1PRMGTKp2oa3DA,HygUu8cgJ3QNxNU4SljBp4" />
-        <Link Id="A7oUShHfkYTOVNsZlkZjLY" Ids="HBrOmQ1KFbvOJgPk3GBERd,N36BpizWwjPLAsAjJeBsgu" />
-        <Link Id="KaEZ7NfBCLRNEMC7HF1O1J" Ids="LhrFItf1N5bQT5deF9Qc8O,Jc78mjHkDsnMwEhZMtkEqP" IsHidden="true" />
-        <Link Id="RujNfWiFkiLNWv6DO9Qv1K" Ids="GUKDl02sYCnN4qhqnrPUW0,FpRyKntfa7cNQU4nGkrxGP" IsHidden="true" />
-        <Link Id="AkAheTbxQugNbi2enDBApM" Ids="Jc78mjHkDsnMwEhZMtkEqP,GaQs7vYj3t2O2qKvAuOicy" />
-        <Link Id="GSEN9cBfLoPLHtvIQcZIrA" Ids="QbL2ksWUWXlQSMuNnDdXhZ,GUKDl02sYCnN4qhqnrPUW0" />
-        <Link Id="AeC45H3zK5SP5yphhw2Axm" Ids="JyjHfNFi4nRLLDhPao51Yh,TYcaKu12KbzMwmS57QZCZ6" />
-        <Link Id="EOROfsPuEKOQWE2ibHcWIe" Ids="JyjHfNFi4nRLLDhPao51Yh,SaIrlKKNJ3XLftihnDR2TW" />
-        <Link Id="BTNZ47j0KSWLNrUsDtZftU" Ids="OTEpIeY0P3bPBQFzxTnBM7,C7oRnlOVVMtPWhyGrEK1KX" />
-        <Link Id="Pzt6HalXz3NPDwexFiXIyK" Ids="OC3QBXtubAaLzWkbVsDnOR,PDgOHLaEek6OKFYGYqSNST" />
-        <Link Id="TVqDaH7nWaPQUwuPh7ZMOK" Ids="RO9elGolHJmLm0s8XfCDbF,MFxpx7daCcfOlphX7JibpL" />
-        <Link Id="AKjh1UaLUi3NL4albm2jW0" Ids="QbL2ksWUWXlQSMuNnDdXhZ,NdoVzjnKgHQOqfdKJ7yNSG" />
-        <Link Id="GKiNrEK3bVgMiggYeMNZFr" Ids="U4pPkv9MW9WLfBwSz94BuP,JyjHfNFi4nRLLDhPao51Yh" />
-        <Link Id="J1R2dioOpOsP0yQq0hqUvB" Ids="NZTZcrBZ353NlKSolQM2OY,M9nam8gLwQGPpMKUNSoAeO" />
+        <Link Id="UVoPhF1ai2JOP3m39racxf" Ids="CmKiit8HlmdOcSBlViimvh,H45tiBJu1BvMsWBUOCbUD7" />
+        <Link Id="BkQoKyDbm6IMGs3mSD2MnM" Ids="BLmWfbeNcxdPg2eZWjjWVo,EYnzxEIyPLuPzLRdtKqYPL" />
+        <Link Id="TzcaC2CvrdmNlxGLaZh03T" Ids="DE6VLioJivnL4FUwZlBzyI,LFUkfNNddgIQAjCm32uDTU" />
+        <Link Id="TKpFvF9zsgHNdMvo7YmXa1" Ids="I481xOkdoytMb1SaTjNJJh,Mn77De0zEdHOI9l5sBohmH" />
+        <Link Id="Jks8QFbTZOGQIfm0bhIbfI" Ids="QIMgDg9S2WhNdpX1ekN98E,L165Iak8JnROxsnD5outxu" />
+        <Link Id="PVUNp8q73SGQKm3PQNUarl" Ids="Mi69FKSBCjpLQ73dtE34pg,CBAyFw77HAYOcLxbInZgbz" />
+        <Link Id="P15JlGIpuaNL7Pwk999CpL" Ids="NXYglHukEEnN05fEkg1ZAg,JpgALS84bihMJHrds6SuEI" />
+        <Link Id="ACnErRVGF7xNO3lyzOs5F9" Ids="CanuygkQveGP9HZMCmzVDi,HlzSTnBUpRvQJytcMNCI4G" />
+        <Link Id="IN7zhbtuz4tLquwHwdv4J8" Ids="KB0YDR2Z0BALMj21rcdnD1,HD45I5GYXH4L3zfYycd2Z5" />
+        <Link Id="EsCWju8t8IQLLXWI9Q0ian" Ids="NXYglHukEEnN05fEkg1ZAg,QfZ9m6IY1YqNZgJf6NsMOm" />
+        <Link Id="SDl9jLgUnnANZjtdNpfuXw" Ids="T3aVd32W6cIQPYb0mZAKMd,SPTZ07HP1FqQdd0wRh0qHk" IsHidden="true" />
+        <Link Id="SmQeugZmO2cOWoqeerfjiO" Ids="VOFmRxXz5SUPVzszZMLaqI,U12SozBCamSNP4cYEaMUoa" IsHidden="true" />
+        <Link Id="QJDnxmXDRTZNtR8X4sKgKa" Ids="E6NihScrkiWN4dgWTzGGnC,Kv994FjaMLsPMGVGRpg2KL" />
+        <Link Id="Ezuh2zPNcTPPBzPmMjUroS" Ids="UgTaKnDm5gJPKrupvdcoXJ,Pbmr54Ssby6M83hJevBMDb" IsFeedback="true" />
+        <Link Id="P9b0eyizuLhLFS43XF8JlP" Ids="M9kNpFxduyzM3MzoAtdiPc,Pbmr54Ssby6M83hJevBMDb" />
+        <Link Id="N4SsDNDdX3tQKXt6tukRwD" Ids="Pbmr54Ssby6M83hJevBMDb,S56Y9AiYspLOLvkAeZtlOD" />
+        <Link Id="ShzpVurdPmXNhbUr1XmSgT" Ids="CjtLvLu5u4BLfFrIUeYrMw,PnvK7ErNvQfLQSOO6CwwxK" IsFeedback="true" />
+        <Link Id="DYFdwdOnEHBNUFGZ2Y5i89" Ids="FGfBTWdp6u3QX7RD97hQ0h,PnvK7ErNvQfLQSOO6CwwxK" />
+        <Link Id="EEsL8Hza0vQQB62FM4ZWMS" Ids="PnvK7ErNvQfLQSOO6CwwxK,PJpQYPgA367MV3sxrog8SV" />
+        <Link Id="PD0bC8oIjYxLjgomiS0clJ" Ids="OCdKKuEUwhoN94NvX5q5LB,M2AZ32j1BFIOtivBi9OzJW" />
+        <Link Id="UPH961pNkhwNSeFSq3VPkB" Ids="E6NihScrkiWN4dgWTzGGnC,CHYhDOwYTd2OwQD9GGuQph" />
+        <Link Id="E9fRqtT8M7iPYJiUyEVfgN" Ids="MyjTYF5KwJyNwGJLOEYW4M,PsKd5xnlhkoPAUn9i7XwRx" />
+        <Link Id="K0ywff12jFEMLf0zEvktIC" Ids="MyjTYF5KwJyNwGJLOEYW4M,CRIQs1VeFKOL6uEdvF0wbC" />
+        <Link Id="CGwEhA4jwP9Lez6hgUfZ6R" Ids="R9jCJyog9gTNyGnWJhyyAU,UlP2AcgiUSrNiXtJ0CVXHZ" />
+        <Link Id="GbgqspYoMxcLPr8c9EInB8" Ids="SPTZ07HP1FqQdd0wRh0qHk,DsCCwiThA7PObNEJo6RaFj" />
+        <Link Id="ShMCx1M3OvIL8ZcioW7KhA" Ids="HwnbkvfAz5eMwRLIzweI72,RxT2QJuV6iFNGm4KKeCH5J" />
+        <Link Id="LJ6KU3INDUuNzmZyKQbSjI" Ids="OpQYtlqJJ2QLmrxDEFsxeQ,B8xrpJGf5zGOvbLvpsYZaY" />
+        <Link Id="BQpIGjYkOKcNGsdF7G4cWY" Ids="MyjTYF5KwJyNwGJLOEYW4M,HwnbkvfAz5eMwRLIzweI72" />
+        <Link Id="Tz685kYY0UYLCC5Irry1RY" Ids="GEPfdbmOumKOf3PnHb1bLK,Cd0V0l8miJmLvJsecsWDoa" />
+        <Link Id="Dj5ruJZUfILMuXQHnDUbEi" Ids="B8xrpJGf5zGOvbLvpsYZaY,NxTgYpQ8r8VOMtSEPWNiOi" />
+        <Link Id="HFQX8EjgfjaPxJwMvWBrTQ" Ids="SHWhlBf3vboQXvSy2DloyW,RwHYRf5xvhsOpfW2prXx73" />
+        <Link Id="F3KkXfsuCEXPwhnH2ZEbvN" Ids="McviIEOUzPdP8SG8tqyieq,FgYr4ihQocVNRIwa4s5386" />
+        <Link Id="HLUfPcGSInnMOleNTQD3DY" Ids="JsqR4qf5AozMRoTiXFimq3,E2AaVzokvJfPMhc04pIc1U" />
+        <Link Id="MDf5uocGSm5Nt3uhlgmrRt" Ids="NcZDXn3Cj1jP6qhOGTJb7H,QNyVJDfoU5cPV2ojmnM2YU" />
+        <Link Id="CDjP6yjXOHlNrkRcwGkPtg" Ids="IYkc47Ip2GhQNxJnkZD0xR,IHMhiaM7lQlMcLvxUKHpPV" />
+        <Link Id="FgL4ekdjvkXNn2n5vLGHmy" Ids="Q1fLPopUEpYOowKAiPnvIQ,NiNrGsQmzdrMC7KgXUusdn" IsFeedback="true" />
+        <Link Id="UMzRAEnYd2MPpzSVLQYe8E" Ids="GZ5IGD7wAQYOq8IH2tKd8Y,JFfrlNcNvhVPRNgdPjxhNe" />
+        <Link Id="MNf3yB4WdZSNLQsE5arsP5" Ids="GZ5IGD7wAQYOq8IH2tKd8Y,H6ynv7symjkMRCDXubfuqY" />
+        <Link Id="KQDC8NAGiW9MnMZdzCOiiO" Ids="Fkl7y2BolsBM34faKq7oYb,A3W2rl3OO1ZPqDNhySe0CB" />
+        <Link Id="Jb7Aa1QEa6YPYF8S4VTs8m" Ids="SVmCTVDZBb0OPUUnAQ2Jzg,Pqv33ctMY8wMffIWrE09ji" IsFeedback="true" />
+        <Link Id="Ex6nOYp7CzvLZWL1cuPWwN" Ids="OC3QBXtubAaLzWkbVsDnOR,Pqv33ctMY8wMffIWrE09ji" />
+        <Link Id="AIN6ysqHvp8PpsaDB2PrbZ" Ids="Pqv33ctMY8wMffIWrE09ji,DmC8Qzc9yhGO6w7NCHmVUR" />
+        <Link Id="CwyIgWOoB3YM0vM1OSNjob" Ids="LsJfWN6N2gcP5i7KV6s4NY,RqWlAUMF60oMrKIQL2akA5" IsFeedback="true" />
+        <Link Id="HT0yBgAlonkNMwpwo0XzN3" Ids="RO9elGolHJmLm0s8XfCDbF,RqWlAUMF60oMrKIQL2akA5" />
+        <Link Id="GF76jKC9pQOPhHGA1LAGBU" Ids="RqWlAUMF60oMrKIQL2akA5,OfWdRkJ82vYPlp3jKis5ys" />
+        <Link Id="SlwnNhuhSOgN1LiWkI1n9E" Ids="OKxlm3NmllCM8mHdqgC9Se,InsmNdQnS0BM9IxcdEcLpz" IsFeedback="true" />
+        <Link Id="OPwYGxvSs1BOjFC6QwGuPm" Ids="KW4K0rpgRw5QPOJ2TXJBiE,Acv4PtAk0vYLYSUhVyHZut" />
+        <Link Id="E20KpsCLOrhNpTdyvpuNb5" Ids="Sr1fwpjHDkyOhTQqA3m2Sw,F2fSQryFcqXN2eNz2gZ3x8" IsFeedback="true" />
+        <Link Id="PBMPagS3fimOTeO4BFaqfm" Ids="HPsti5cPXgFMFUJYdKrbO7,F2fSQryFcqXN2eNz2gZ3x8" />
+        <Link Id="GSyjYYwMqvlOIc0kQLQGr5" Ids="AFIQU4olKDIMVPzmkyps37,BOaewLL7ypWPVE8GDdi1Qn" IsFeedback="true" />
+        <Link Id="VvAlUJmdImeLViPuBpMiuo" Ids="BOaewLL7ypWPVE8GDdi1Qn,C3plj8tC09xLsKKgrsHqKG" />
+        <Link Id="VfIZLaALNzZN3HPGeGiE9i" Ids="MTj3z03XouPMomVxzKVx5D,I5UahQXCTinMFXPFh2wl8U" />
+        <Link Id="C7WHI6bk4njLoLYB3VcMrf" Ids="MTj3z03XouPMomVxzKVx5D,GGNyv50dpXXLtpZAa6G15e" />
+        <Link Id="ExM9VQYsapMMlaEwKHCI2s" Ids="H6ynv7symjkMRCDXubfuqY,F9xMiDoXOEsM55Ii6A5C7M" />
+        <Link Id="TMgagELQNWVP1Jhxuk5XW7" Ids="H6ynv7symjkMRCDXubfuqY,M9nam8gLwQGPpMKUNSoAeO" />
+        <Link Id="AUFuQ1EkHjrN6AvCLK17XH" Ids="Fkl7y2BolsBM34faKq7oYb,GtsFep2ERP7NgubNlFV06A" />
+        <Link Id="VlpggipqDJSLARhkXYcCAF" Ids="JFfrlNcNvhVPRNgdPjxhNe,Iq9d9hMYWBTMqNbUdOTEiJ" />
+        <Link Id="VqN49uRpnaXMBDFNwJisMA" Ids="BZg6h6ve2F1L6em4PDp6La,LmftNs7PPbCQOEFajuaWQS" />
+        <Link Id="InxZnRo668FLb3FCODJgJh" Ids="F9sNuFQYz9PNzgUzbPUrXT,AYcW1OvSOI4NpH4HDY1Sd2" IsFeedback="true" />
+        <Link Id="EcBsrDIEfMgQcV17IGibIo" Ids="LmftNs7PPbCQOEFajuaWQS,AYcW1OvSOI4NpH4HDY1Sd2" />
+        <Link Id="UVY7vooOpR0L9zOUDdnhKs" Ids="AYcW1OvSOI4NpH4HDY1Sd2,BOaewLL7ypWPVE8GDdi1Qn" />
+        <Link Id="NXTod9CMvAuPtE2VUXcvuI" Ids="Ml31fnQmpeyNcXezuwK9hB,DSuyMzoWmNYLdgymWlrFfl" IsHidden="true" />
+        <Link Id="EDltjuWCaleNeRD4j3bUZA" Ids="MWADKiG6mipMsMxeXQfMwr,BajTMx5SUO1LwD69uRGAdv" IsHidden="true" />
+        <Link Id="Lbm9t0thcT3MN6SNu1m8i6" Ids="DSuyMzoWmNYLdgymWlrFfl,MWADKiG6mipMsMxeXQfMwr" />
+        <Link Id="N8poYYPWJ1VLms7HojUQbO" Ids="Vlg2VAIJpl4MBpMPZksMy7,PK6JjpBzrEENsGPzhGokp0" />
+        <Link Id="CQi8EYiKfADNJ1tHYwtJOO" Ids="QIMgDg9S2WhNdpX1ekN98E,DiI9wIqhGAVMdFTo1KEfUe" />
+        <Link Id="FHQyq6EEU8OLuR8wMATAhe" Ids="DSuyMzoWmNYLdgymWlrFfl,LnbtUZ2qAkYM8JKUXyY0uP" />
+        <Link Id="Ja3xiBUkjC9NIrgksg8wIq" Ids="Q5AlbwOTiuUNXYogi9JHQX,VOFmRxXz5SUPVzszZMLaqI" />
+        <Link Id="M6a5Emg9GBWLGl0ZBeyG2Q" Ids="Q5AlbwOTiuUNXYogi9JHQX,L2mk1DMjnEvM78vMrgH2KK" />
+        <Link Id="PdPkTFual73Nhkg9h4Vphn" Ids="SPTZ07HP1FqQdd0wRh0qHk,JOoDoqYZQ6FNMsTj55RyQV" />
+        <Link Id="JfWaATpLJ3ALNpiB1vafZR" Ids="Ffcm2NjRIruOYUS8AewXLv,Qicp6ZNUAyhMvgo6f7BPOF" />
+        <Link Id="UU5k1KGSTEyPz3yHcTeLjN" Ids="IPmPTJA561wPzaGbDDNuzZ,CBgNPoWUn0ZNsFk1iyTFkh" />
+        <Link Id="ApCLkG7eZBhLaZKHAH4jkg" Ids="LnQecV2iucfOwOOoZlrtU1,Qv208sfboQ3M0L3lYzbX4z" />
+        <Link Id="H9Gqstk3hDbPTi9GvW4vXj" Ids="MDd0ArB9xb3Mv47wvmmzLj,TgV9wdnb0tgO7rRt3PfXIp" />
+        <Link Id="DwGANM0VsFLMBpXvoindfS" Ids="MWzZQDXJLkePFwXQOqcKju,Gf9zGFH0ZjyN8EybWrYsmE" />
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="RZ1cz496dpgNj0r1GJdwKs" Location="VL.HDE" Version="2024.6.7-0145-g7866bdf1e8" />
-  <NugetDependency Id="IdDPloCqQavPJlhM5jY3Lb" Location="VL.Skia" Version="2024.6.7-0145-g7866bdf1e8" />
-  <NugetDependency Id="U4rnJ58Je0dMe7sTAiWUhv" Location="VL.CoreLib.Windows" Version="2024.6.7-0145-g7866bdf1e8" />
+  <NugetDependency Id="RZ1cz496dpgNj0r1GJdwKs" Location="VL.HDE" Version="2025.7.0" />
+  <NugetDependency Id="IdDPloCqQavPJlhM5jY3Lb" Location="VL.Skia" Version="2025.7.0" />
+  <NugetDependency Id="U4rnJ58Je0dMe7sTAiWUhv" Location="VL.CoreLib.Windows" Version="2025.7.0" />
   <NugetDependency Id="DiyopvFORXsL9vcuSxq8da" Location="MouseKeyHook" Version="5.6.0" />
   <PlatformDependency Id="JEqMcDRh80UMFl2nW9lkrm" Location="System.Windows.Forms" />
   <PlatformDependency Id="VBlSblYJ1AfPmk6OWRuYcU" Location="System.Drawing" />


### PR DESCRIPTION
The current version of VL.Pipette doesn't use the Window factory and so fails to show the renderer. This change allows it to be tabbed.
However, I'm not sure if the result is the best use for the HDE framework, and if breaking changes are avoidable for version 6.7